### PR TITLE
Add a "Recent Changes" page

### DIFF
--- a/candidates/templates/candidates/recent-changes.html
+++ b/candidates/templates/candidates/recent-changes.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+
+{% block body_class %}{% endblock %}
+
+{% block title %}Recent changes to the candidate (PPC) database{% endblock %}
+
+{% block hero %}
+  <h1>Recent Changes</h1>
+{% endblock %}
+
+{% block content %}
+
+<table>
+  <tr>
+    <th>User</th>
+    <th>Date and time</th>
+    <th>Action</th>
+    <th>Candidate edited</th>
+    <th>Information source</th>
+  </tr>
+  {% for action in actions %}
+    <tr>
+      <td>{{ action.user.username }}</td>
+      <td>{{ action.created }}</td>
+      <td>{{ action.action_type }}</td>
+      <td><a href="{% url 'person-view' person_id=action.popit_person_id %}">{{ action.popit_person_id }}</a></td>
+      <td>{{ action.source }}</td>
+    </tr>
+  {% endfor %}
+</table>
+
+<div class="pagination">
+    <span class="step-links">
+        {% if actions.has_previous %}
+            <a href="?page={{ actions.previous_page_number }}">previous</a>
+        {% endif %}
+
+        <span class="current">
+            Page {{ actions.number }} of {{ actions.paginator.num_pages }}.
+        </span>
+
+        {% if actions.has_next %}
+            <a href="?page={{ actions.next_page_number }}">next</a>
+        {% endif %}
+    </span>
+</div>
+
+{% endblock %}

--- a/candidates/tests/test_recent_changes_view.py
+++ b/candidates/tests/test_recent_changes_view.py
@@ -1,0 +1,34 @@
+from django_webtest import WebTest
+
+from .auth import TestUserMixin
+from ..models import LoggedAction
+
+class TestRecentChangesView(TestUserMixin, WebTest):
+
+    def setUp(self):
+        self.action1 = LoggedAction.objects.create(
+            user=self.user,
+            action_type='person-create',
+            ip_address='127.0.0.1',
+            popit_person_id='9876',
+            popit_person_new_version='1234567890abcdef',
+            source='Just for tests...',
+        )
+        self.action2 = LoggedAction.objects.create(
+            user=self.user,
+            action_type='candidacy-delete',
+            ip_address='127.0.0.1',
+            popit_person_id='1234',
+            popit_person_new_version='987654321',
+            source='Also just for testing',
+        )
+
+    def tearDown(self):
+        self.action2.delete()
+        self.action1.delete()
+
+    def test_recent_changes_page(self):
+        # Just a smoke test to check that the page loads:
+        response = self.app.get('/recent-changes')
+        table = response.html.find('table')
+        self.assertEqual(3, len(table.find_all('tr')))

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -5,7 +5,8 @@ from django.contrib import admin
 from candidates.views import (ConstituencyPostcodeFinderView,
     ConstituencyNameFinderView, ConstituencyDetailView, CandidacyView,
     CandidacyDeleteView, NewPersonView, UpdatePersonView, RevertPersonView,
-    PersonView, HelpApiView, HelpAboutView, ConstituencyListView)
+    PersonView, HelpApiView, HelpAboutView, ConstituencyListView,
+    RecentChangesView)
 
 urlpatterns = patterns('',
     url(r'^$', ConstituencyPostcodeFinderView.as_view(), name='finder'),
@@ -33,6 +34,9 @@ urlpatterns = patterns('',
     url(r'^person/(?P<person_id>.*)$',
         PersonView.as_view(),
         name='person-view'),
+    url(r'^recent-changes$',
+        RecentChangesView.as_view(),
+        name='recent-changes'),
     url(r'^help/api', HelpApiView.as_view(), name='help-api'),
     url(r'^help/about', HelpAboutView.as_view(), name='help-about'),
     url(r'^admin/', include(admin.site.urls)),

--- a/candidates/views.py
+++ b/candidates/views.py
@@ -7,6 +7,7 @@ import sys
 from slugify import slugify
 import requests
 
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.http import urlquote
@@ -527,3 +528,19 @@ class HelpApiView(PopItApiMixin, TemplateView):
 
 class HelpAboutView(TemplateView):
     template_name = 'candidates/about.html'
+
+class RecentChangesView(TemplateView):
+    template_name = 'candidates/recent-changes.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(RecentChangesView, self).get_context_data(**kwargs)
+        actions = LoggedAction.objects.all().order_by('-created')
+        paginator = Paginator(actions, 50)
+        page = self.request.GET.get('page')
+        try:
+            context['actions'] = paginator.page(page)
+        except PageNotAnInteger:
+            context['actions'] = paginator.page(1)
+        except EmptyPage:
+            context['actions'] = paginator.page(paginator.num_pages)
+        return context

--- a/mysite/templates/base.html
+++ b/mysite/templates/base.html
@@ -29,6 +29,7 @@
         <a href="{% url 'help-api' %}" class="header__nav__logo">API</a>
         <a href="{% url 'help-about' %}" class="header__nav__logo">About</a>
         <a href="{% url 'constituencies' %}" class="header__nav__logo">Constituencies</a>
+        <a href="{% url 'recent-changes' %}" class="header__nav__logo">Recent Changes</a>
         {% if user.is_authenticated %}
           <span class="header__nav__logout">
             Signed in as <strong>{{ user.username }}</strong>


### PR DESCRIPTION
This shows, from most recent to least recent, paginated, all the actions
users have taken on the site.  This should make it easier for anyone to
review what other people have been adding to the database.

Fixes #72
