### PR TITLE
Add simple 'All time' and 'In the last week' leaderboards

### DIFF
--- a/candidates/templates/candidates/leaderboard.html
+++ b/candidates/templates/candidates/leaderboard.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+
+{% block body_class %}{% endblock %}
+
+{% block title %}Recent changes to the candidate (PPC) database{% endblock %}
+
+{% block hero %}
+  <h1>Top Users</h1>
+{% endblock %}
+
+{% block content %}
+
+{% for leaderboard in leaderboards %}
+
+  <h2>{{ leaderboard.title }}</h2>
+
+  <table>
+    <tr>
+      <th>User</th>
+      <th>Number of edits</th>
+    </tr>
+    {% for row in leaderboard.rows %}
+      <tr>
+        <td>{{ row.username }}</td>
+        <td>{{ row.edit_count }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+
+{% endfor %}
+
+{% endblock %}

--- a/candidates/tests/test_leaderboard.py
+++ b/candidates/tests/test_leaderboard.py
@@ -1,0 +1,57 @@
+from django.contrib.auth.models import User
+
+from django_webtest import WebTest
+
+from .auth import TestUserMixin
+from ..models import LoggedAction
+
+class TestLeaderboardView(TestUserMixin, WebTest):
+
+    def setUp(self):
+        self.user2 = User.objects.create_user(
+            'jane',
+            'jane@example.com',
+            'notagoodpassword',
+        )
+        self.action1 = LoggedAction.objects.create(
+            user=self.user,
+            action_type='person-create',
+            ip_address='127.0.0.1',
+            popit_person_id='9876',
+            popit_person_new_version='1234567890abcdef',
+            source='Just for tests...',
+        )
+        self.action2 = LoggedAction.objects.create(
+            user=self.user2,
+            action_type='candidacy-delete',
+            ip_address='127.0.0.1',
+            popit_person_id='1234',
+            popit_person_new_version='987654321',
+            source='Also just for testing',
+        )
+        self.action2 = LoggedAction.objects.create(
+            user=self.user2,
+            action_type='candidacy-delete',
+            ip_address='127.0.0.1',
+            popit_person_id='1234',
+            popit_person_new_version='987654321',
+            source='Also just for testing',
+        )
+
+    def tearDown(self):
+        self.action2.delete()
+        self.action1.delete()
+        self.user2.delete()
+
+    def test_recent_changes_page(self):
+        # Just a smoke test to check that the page loads:
+        response = self.app.get('/leaderboard')
+        table = response.html.find('table')
+        rows = table.find_all('tr')
+        self.assertEqual(3, len(rows))
+        first_row = rows[1]
+        cells = first_row.find_all('td')
+        self.assertEqual(cells[0].text, self.user2.username)
+        second_row = rows[2]
+        cells = second_row.find_all('td')
+        self.assertEqual(cells[0].text, self.user.username)

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -6,7 +6,7 @@ from candidates.views import (ConstituencyPostcodeFinderView,
     ConstituencyNameFinderView, ConstituencyDetailView, CandidacyView,
     CandidacyDeleteView, NewPersonView, UpdatePersonView, RevertPersonView,
     PersonView, HelpApiView, HelpAboutView, ConstituencyListView,
-    RecentChangesView)
+    RecentChangesView, LeaderboardView)
 
 urlpatterns = patterns('',
     url(r'^$', ConstituencyPostcodeFinderView.as_view(), name='finder'),
@@ -37,6 +37,9 @@ urlpatterns = patterns('',
     url(r'^recent-changes$',
         RecentChangesView.as_view(),
         name='recent-changes'),
+    url(r'^leaderboard$',
+        LeaderboardView.as_view(),
+        name='leaderboard'),
     url(r'^help/api', HelpApiView.as_view(), name='help-api'),
     url(r'^help/about', HelpAboutView.as_view(), name='help-about'),
     url(r'^admin/', include(admin.site.urls)),

--- a/mysite/templates/base.html
+++ b/mysite/templates/base.html
@@ -30,6 +30,7 @@
         <a href="{% url 'help-about' %}" class="header__nav__logo">About</a>
         <a href="{% url 'constituencies' %}" class="header__nav__logo">Constituencies</a>
         <a href="{% url 'recent-changes' %}" class="header__nav__logo">Recent Changes</a>
+        <a href="{% url 'leaderboard' %}" class="header__nav__logo">Top Users</a>
         {% if user.is_authenticated %}
           <span class="header__nav__logout">
             Signed in as <strong>{{ user.username }}</strong>


### PR DESCRIPTION
This could do with some design attention (they're just two plain tables
at the moment) but adds leaderboards of users based on the top 10 number
of edits for "all time" and "in the last week".

This may not be the right incentive, so if this seems to be having a bad
effect, we might want to change this to hide the number of edits, as Tim
Green (@tfgg) suggested.

Fixes #66
