### PR TITLE
Prompt with more detail about the kinds of sources we like

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -3,6 +3,7 @@ import re
 from .static_data import MapItData, PartyData
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 
 class PostcodeForm(forms.Form):
@@ -37,13 +38,17 @@ class BaseCandidacyForm(forms.Form):
 
 class CandidacyCreateForm(BaseCandidacyForm):
     source = forms.CharField(
-        label="Source of information that they're standing",
+        label=u"Source of information that they're standing ({0})".format(
+            settings.SOURCE_HINTS
+        ),
         max_length=512,
     )
 
 class CandidacyDeleteForm(BaseCandidacyForm):
     source = forms.CharField(
-        label="Information source for this change",
+        label=u"Information source for this change ({0})".format(
+            settings.SOURCE_HINTS
+        ),
         max_length=512,
     )
 
@@ -149,7 +154,9 @@ class NewPersonForm(BasePersonForm):
         required=False,
     )
     source = forms.CharField(
-        label="Source of information",
+        label=u"Source of information ({0})".format(
+            settings.SOURCE_HINTS
+        ),
         max_length=512,
         error_messages={
             'required': 'You must indicate how you know about this candidate'
@@ -199,7 +206,9 @@ class UpdatePersonForm(BasePersonForm):
         required=False,
     )
     source = forms.CharField(
-        label="Source of information for this change",
+        label=u"Source of information for this change ({0})".format(
+            settings.SOURCE_HINTS
+        ),
         max_length=512,
         error_messages={
             'required': 'You must indicate how you know about this candidate'

--- a/candidates/templates/candidates/_source_confirmation.html
+++ b/candidates/templates/candidates/_source_confirmation.html
@@ -3,7 +3,7 @@
     {% csrf_token %}
     <input type="hidden" name="person_id" value="{{ c.id }}"/>
     <input type="hidden" name="mapit_area_id" value="{{ mapit_area_id }}"/>
-    <label for="id_source">Before we save that, can you show us <em>where</em> you heard it?</label>
+    <label for="id_source">Before we save that, can you show us <em>where</em> you heard it? {{ source_hints }}</label>
     <div class="row">
       <div class="small-12 medium-8 large-9 columns">
         <input type="text" name="source" id="id_source" maxlength="512" required="required"/>

--- a/candidates/views.py
+++ b/candidates/views.py
@@ -8,6 +8,7 @@ from slugify import slugify
 import requests
 
 from django.db.models import Count
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
@@ -190,6 +191,8 @@ class ConstituencyDetailView(PopItApiMixin, TemplateView):
         context['add_candidate_form'] = NewPersonForm(
             initial={'constituency': mapit_area_id}
         )
+
+        context['source_hints'] = settings.SOURCE_HINTS
 
         return context
 

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -234,3 +234,6 @@ NOSE_ARGS = [
     '--with-coverage',
     '--cover-package=candidates'
 ]
+
+SOURCE_HINTS = u'''Please don't quote third-party candidate sites \u2014
+we prefer URLs of news stories or official candidate pages.'''


### PR DESCRIPTION
There have been a few cases where people have used a third-party
candidate site as a source for their information, whereas we want
sources like newspaper reports or official party pages.

This commit adds the following wording into each source prompt:

  Please don't quote other third-party candidate sites -
  we prefer URLs of news stories or official party pages.

Fixes #84
