### PR TITLE
Remove brackets around candidate party on constituency page

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,10 @@ the development server again are:
 
     cd yournextmp-popit
     ./manage.py runserver 0.0.0.0:8000
+
+### Running the tests
+
+SSH into the vagrant machine, then run:
+
+    cd yournextmp-popit
+    ./manage.py test

--- a/candidates/static/candidates/_people.scss
+++ b/candidates/static/candidates/_people.scss
@@ -21,6 +21,18 @@
 
   .person-name-and-party {
     font-size: 1.2em;
+
+    .party {
+      color: darken($color-cream, 20%);
+      margin-left: 0.2em;
+
+      &:before {
+        display: inline;
+        content: "–";
+        color: darken($color-cream, 5%);
+        margin-right: 0.4em;
+      }
+    }
   }
 }
 

--- a/candidates/templates/candidates/_person_in_list.html
+++ b/candidates/templates/candidates/_person_in_list.html
@@ -12,10 +12,10 @@
 <div class="person-name-and-party">
   <a href="{% url 'person-view' c.id c.name|slugify %}">{{ c.name }}</a>
   {% if year == '2015' %}
-    ({{c.parties.2015.name }})
+    <span class="party">{{c.parties.2015.name }}</span>
   {% elif year == '2010' %}
-    ({{c.parties.2010.name }})
+    <span class="party">{{c.parties.2010.name }}</span>
   {% else %}
-    (BUG: UNKNOWN YEAR)
+    <span class="party">BUG: UNKNOWN YEAR</span>
   {% endif %}
 </div>

--- a/candidates/tests/test_constituency_view.py
+++ b/candidates/tests/test_constituency_view.py
@@ -16,7 +16,7 @@ class TestConstituencyDetailView(TestUserMixin, WebTest):
 
         # Just a smoke test for the moment:
         response = self.app.get('/constituency/65808/dulwich-and-west-norwood')
-        response.mustcontain('<a href="/person/2009/tessa-jowell">Tessa Jowell</a> (Labour Party)')
+        response.mustcontain('<a href="/person/2009/tessa-jowell">Tessa Jowell</a> <span class="party">Labour Party</span>')
         # There should be no forms on the page if you're not logged in:
 
         self.assertEqual(0, len(response.forms))
@@ -31,6 +31,6 @@ class TestConstituencyDetailView(TestUserMixin, WebTest):
             '/constituency/65808/dulwich-and-west-norwood',
             user=self.user
         )
-        response.mustcontain('<a href="/person/2009/tessa-jowell">Tessa Jowell</a> (Labour Party)')
+        response.mustcontain('<a href="/person/2009/tessa-jowell">Tessa Jowell</a> <span class="party">Labour Party</span>')
         form = response.forms['new-candidate-form']
         self.assertTrue(form)


### PR DESCRIPTION
Fixes #124.

Makes candidate parties a bit easier to parse – especially for UKIP candidates who already have brackets in the party name.

![screen shot 2015-01-07 at 22 23 01](https://cloud.githubusercontent.com/assets/739624/5654529/fab8e8bc-96bb-11e4-85a5-51ed5f0afcf3.png)


<!---
@huboard:{"order":64.0,"milestone_order":127,"custom_state":""}
-->
