### PR TITLE
Add a (superuser only) option to merge two people

### DIFF
--- a/candidates/migrations/0004_auto__add_personredirect.py
+++ b/candidates/migrations/0004_auto__add_personredirect.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'PersonRedirect'
+        db.create_table(u'candidates_personredirect', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('old_person_id', self.gf('django.db.models.fields.IntegerField')()),
+            ('new_person_id', self.gf('django.db.models.fields.IntegerField')()),
+        ))
+        db.send_create_signal(u'candidates', ['PersonRedirect'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'PersonRedirect'
+        db.delete_table(u'candidates_personredirect')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'candidates.loggedaction': {
+            'Meta': {'object_name': 'LoggedAction'},
+            'action_type': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'popit_person_id': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'popit_person_new_version': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'source': ('django.db.models.fields.TextField', [], {}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        u'candidates.maxpopitids': {
+            'Meta': {'object_name': 'MaxPopItIds'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_id': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'popit_collection_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'candidates.personredirect': {
+            'Meta': {'object_name': 'PersonRedirect'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'new_person_id': ('django.db.models.fields.IntegerField', [], {}),
+            'old_person_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['candidates']

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -14,7 +14,7 @@ from slumber.exceptions import HttpServerError
 from .static_data import MapItData
 
 form_simple_fields = ('name', 'email', 'birth_date', 'gender')
-preserve_fields = ('identifiers',)
+preserve_fields = ('identifiers', 'other_names', 'phone')
 
 form_complex_fields_locations = {
     'wikipedia_url': {

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -489,3 +489,12 @@ class LoggedAction(models.Model):
     updated = models.DateTimeField(auto_now=True)
     ip_address = models.CharField(max_length=50, blank=True, null=True)
     source = models.TextField()
+
+
+class PersonRedirect(models.Model):
+    '''This represents a redirection from one person ID to another
+
+    This is typically used to redirect from the person that is deleted
+    after two people are merged'''
+    old_person_id = models.IntegerField()
+    new_person_id = models.IntegerField()

--- a/candidates/popit.py
+++ b/candidates/popit.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from urlparse import urlunsplit
 
 from django.conf import settings
@@ -34,6 +35,50 @@ def popit_unwrap_pagination(api_collection, **kwargs):
         page += 1
         for api_object in response['result']:
             yield api_object
+
+def merge_popit_dicts(primary, secondary):
+    result = {}
+    for key in set(primary.keys() + secondary.keys()):
+        if primary.get(key) and not secondary.get(key):
+            result[key] = primary[key]
+        elif secondary.get(key) and not primary.get(key):
+            result[key] = secondary[key]
+        elif key in primary:
+            result[key] = primary[key]
+        else:
+            result[key] = secondary[key]
+    return result
+
+def merge_popit_arrays(primary_array, secondary_array):
+    # This isn't very efficient, but unlike the more efficient:
+    #    return primary_array + list(set(secondary_array) - set(primary_array))
+    # ... the following works even if elements of the list are
+    # unhashable (e.g. dicts):
+    return primary_array + [e for e in secondary_array if e not in primary_array]
+
+def merge_popit_people(primary, secondary):
+    result = deepcopy(secondary)
+    for primary_key, primary_value in primary.items():
+        # If there's no value in primary, don't write that over
+        # whatever's in the secondary:
+        if not primary_value:
+            continue
+        secondary_value = secondary.get(primary_key)
+        if primary_key == 'name' and secondary_value:
+            if primary_value != secondary_value:
+                # Then the names conflict; add the secondary name to
+                # 'other_names' to preserve it.
+                other_names = result.get('other_names', [])
+                other_names.append({'name': secondary_value})
+                result['other_names'] = other_names
+        if isinstance(primary_value, list) and isinstance(secondary_value, list):
+            result[primary_key] = merge_popit_arrays(primary_value, secondary_value)
+        elif isinstance(primary_value, dict) and isinstance(secondary_value, dict):
+            result[primary_key] = merge_popit_dicts(primary_value, secondary_value)
+        else:
+            result[primary_key] = primary_value
+    return result
+
 
 class PopItApiMixin(object):
 

--- a/candidates/templates/candidates/person-edit.html
+++ b/candidates/templates/candidates/person-edit.html
@@ -19,6 +19,21 @@
     </div>
   </div>
 
+  {% if user.is_superuser %}
+    <div class="row">
+      <div class="columns">
+        <form id="person-merge" action="{% url 'person-merge' person_id=person.id %}" method="post">
+          {% csrf_token %}
+          <p>
+            <label for="other">Other person to merge into this one:</label>
+            <input id="other" name="other" placeholder="Other person ID" type="text"></input>
+          </p>
+          <input type="submit" class="button" value="Merge people">
+        </form>
+      </div>
+    </div>
+  {% endif %}
+
 {% include 'candidates/person-versions.html' %}
 
 {% endblock %}

--- a/candidates/templates/candidates/person-edit.html
+++ b/candidates/templates/candidates/person-edit.html
@@ -7,12 +7,17 @@
 {% endblock %}
 
 {% block content %}
-  <form id="person-details" action="{% url 'person-update' person_id=person.id %}" method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <p>Trying to upload a photo?  Please email <a href="mailto:yournextmp@mysociety.org">yournextmp@mysociety.org</a> and we'll upload it for you.</p>
-    <input type="submit" class="button" value="Save changes">
-  </form>
+
+  <div class="row">
+    <div class="columns">
+      <form id="person-details" action="{% url 'person-update' person_id=person.id %}" method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <p>Trying to upload a photo?  Please email <a href="mailto:yournextmp@mysociety.org">yournextmp@mysociety.org</a> and we'll upload it for you.</p>
+        <input type="submit" class="button" value="Save changes">
+      </form>
+    </div>
+  </div>
 
 {% include 'candidates/person-versions.html' %}
 

--- a/candidates/templates/candidates/person-versions.html
+++ b/candidates/templates/candidates/person-versions.html
@@ -1,57 +1,58 @@
 {% load prettyjson %}
 
-<div class="versions">
-
-<h3>All versions</h3>
-  {% for version in versions %}
-    <div class="version">
-      <div class="version-metadata">
-        <div>
-          <span class="version-metadata-key">Username:</span>
-          <span class="version-metadata-value">{{ version.username }}</span>
+<div class="versions row">
+  <div class="columns">
+    <h3>All versions</h3>
+    {% for version in versions %}
+      <div class="version">
+        <div class="version-metadata">
+          <div>
+            <span class="version-metadata-key">Username:</span>
+            <span class="version-metadata-value">{{ version.username }}</span>
+          </div>
+          <div>
+            <span class="version-metadata-key">Timestamp:</span>
+            <span class="version-metadata-value">{{ version.timestamp }}</span>
+          </div>
+          <div>
+            <span class="version-metadata-key">Source of information:</span>
+            <span class="version-metadata-value">{{ version.information_source }}</span>
+          </div>
+          <div>
+            <span class="version-metadata-key">Changes made:</span>
+            <p>
+            {% for operation in version.diff %}
+              {% if operation.op == 'add' %}
+                 <span class="version-op-add">Added {{ operation.path }} => {{ operation.value|prettyjson }}</span>
+              {% elif operation.op == 'remove' %}
+                 <span class="version-op-remove">Removed {{ operation.path }} (previously it was {{ operation.previous_value|prettyjson }})</span>
+              {% elif operation.op == 'replace' %}
+                 <span class="version-op-replace">At {{ operation.path }} replaced {{ operation.previous_value|prettyjson }} with {{ operation.value|prettyjson }}</span>
+              {% else %}
+                 <span class="version-op-unknown">UNEXPECTED OPERATION: {{ operation|prettyjson }}</span>
+              {% endif %}<br/>
+            {% endfor %}
+            </p>
+          </div>
+          <div>
+            <span class="version-metadata-key">Full version ({{ version.version_id }}):
+              <a class="button tiny js-toggle-full-version-json">Hide</a>
+            </span>
+            <pre class="full-version-json">{{ version.data|prettyjson }}</pre>
+          </div>
         </div>
-        <div>
-          <span class="version-metadata-key">Timestamp:</span>
-          <span class="version-metadata-value">{{ version.timestamp }}</span>
-        </div>
-        <div>
-          <span class="version-metadata-key">Source of information:</span>
-          <span class="version-metadata-value">{{ version.information_source }}</span>
-        </div>
-        <div>
-          <span class="version-metadata-key">Changes made:</span>
-          <p>
-          {% for operation in version.diff %}
-            {% if operation.op == 'add' %}
-               <span class="version-op-add">Added {{ operation.path }} => {{ operation.value|prettyjson }}</span>
-            {% elif operation.op == 'remove' %}
-               <span class="version-op-remove">Removed {{ operation.path }} (previously it was {{ operation.previous_value|prettyjson }})</span>
-            {% elif operation.op == 'replace' %}
-               <span class="version-op-replace">At {{ operation.path }} replaced {{ operation.previous_value|prettyjson }} with {{ operation.value|prettyjson }}</span>
-            {% else %}
-               <span class="version-op-unknown">UNEXPECTED OPERATION: {{ operation|prettyjson }}</span>
-            {% endif %}<br/>
-          {% endfor %}
-          </p>
-        </div>
-        <div>
-          <span class="version-metadata-key">Full version ({{ version.version_id }}):
-            <a class="button tiny js-toggle-full-version-json">Hide</a>
-          </span>
-          <pre class="full-version-json">{{ version.data|prettyjson }}</pre>
-        </div>
-      </div>
-      {% if user.is_authenticated %}
-        {% if not forloop.first %}
-          <form action="{% url 'person-revert' person_id=person.id %}" method="post">
-            {% csrf_token %}
-            <input type="hidden" name="version_id" value="{{ version.version_id }}"/>
-            <input type="text" name="source" id="id_source" maxlength="512" required="required" value="Reverting to version {{ version.version_id }} because ..."/>
-            <input type="submit" class="button tiny" value="Revert to this version" />
-          </form>
+        {% if user.is_authenticated %}
+          {% if not forloop.first %}
+            <form action="{% url 'person-revert' person_id=person.id %}" method="post">
+              {% csrf_token %}
+              <input type="hidden" name="version_id" value="{{ version.version_id }}"/>
+              <input type="text" name="source" id="id_source" maxlength="512" required="required" value="Reverting to version {{ version.version_id }} because ..."/>
+              <input type="submit" class="button tiny" value="Revert to this version" />
+            </form>
+          {% endif %}
         {% endif %}
-      {% endif %}
-    </div>
+      </div>
 
-  {% endfor %}
+    {% endfor %}
+  </div>
 </div>

--- a/candidates/tests/test_merge_people.py
+++ b/candidates/tests/test_merge_people.py
@@ -1,0 +1,320 @@
+from django.test import TestCase
+
+from ..popit import merge_popit_people
+
+class TestMergePeople(TestCase):
+
+    def test_merge_basic_unknown_details(self):
+        primary = {
+            'foo': 'bar',
+            'quux': 'xyzzy',
+        }
+        secondary = {
+            'foo': 'baz',
+            'hello': 'goodbye',
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'foo': 'bar',
+                'quux': 'xyzzy',
+                'hello': 'goodbye',
+            }
+        )
+
+    def test_merge_arrays(self):
+        primary = {
+            'some-list': ['a', 'b', 'c'],
+        }
+        secondary = {
+            'some-list': ['b', 'c', 'd'],
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'some-list': ['a', 'b', 'c', 'd'],
+            }
+        )
+
+    def test_merge_array_primary_null(self):
+        primary = {
+            'some-list': None,
+        }
+        secondary = {
+            'some-list': ['a', 'b', 'c'],
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'some-list': ['a', 'b', 'c'],
+            }
+        )
+
+    def test_merge_array_primary_null(self):
+        primary = {
+            'some-list': None,
+        }
+        secondary = {
+            'some-list': ['a', 'b', 'c'],
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'some-list': ['a', 'b', 'c'],
+            }
+        )
+
+    def test_merge_array_secondary_null(self):
+        primary = {
+            'some-list': ['a', 'b', 'c'],
+        }
+        secondary = {
+            'some-list': None,
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'some-list': ['a', 'b', 'c'],
+            }
+        )
+
+    def test_merge_standing_in_contradicting(self):
+        primary = {
+            'standing_in': {
+                '2010': {
+                    'name': 'Edinburgh East',
+                    'post_id': '14419',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14419',
+                },
+                '2015': {
+                    'name': 'Edinburgh North and Leith',
+                    'post_id': '14420',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14420',
+                },
+            }
+        }
+        secondary = {
+            'standing_in': {
+                '2010': {
+                    'name': 'Aberdeen South',
+                    'post_id': '14399',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14399',
+                },
+                '2015': {
+                    'name': 'Aberdeen North',
+                    'post_id': '14398',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14398',
+                },
+            },
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'standing_in': {
+                    '2010': {
+                        'name': 'Edinburgh East',
+                        'post_id': '14419',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14419',
+                    },
+                    '2015': {
+                        'name': 'Edinburgh North and Leith',
+                        'post_id': '14420',
+                        'mapit_url': 'http://mapit.mysociety.org/area/14420',
+                    },
+                }
+            }
+        )
+
+    def test_merge_standing_in_2015_null_in_primary(self):
+        primary = {
+            'standing_in': {
+                '2010': {
+                    'name': 'Edinburgh East',
+                    'post_id': '14419',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14419',
+                },
+                '2015': None,
+            }
+        }
+        secondary = {
+            'standing_in': {
+                '2010': {
+                    'name': 'Aberdeen South',
+                    'post_id': '14399',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14399',
+                },
+                '2015': {
+                    'name': 'Aberdeen North',
+                    'post_id': '14398',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14398',
+                },
+            },
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'standing_in': {
+                    '2010': {
+                        'name': 'Edinburgh East',
+                        'post_id': '14419',
+                        'mapit_url': 'http://mapit.mysociety.org/area/14419',
+                    },
+                    '2015': {
+                        'name': 'Aberdeen North',
+                        'post_id': '14398',
+                        'mapit_url': 'http://mapit.mysociety.org/area/14398',
+                    },
+                }
+            }
+        )
+
+    def test_merge_standing_in_2015_null_in_secondary(self):
+        primary = {
+            'standing_in': {
+                '2010': {
+                    'name': 'Edinburgh East',
+                    'post_id': '14419',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14419',
+                },
+                '2015': {
+                    'name': 'Edinburgh North and Leith',
+                    'post_id': '14420',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14420',
+                },
+            }
+        }
+        secondary = {
+            'standing_in': {
+                '2010': {
+                    'name': 'Aberdeen South',
+                    'post_id': '14399',
+                    'mapit_url': 'http://mapit.mysociety.org/area/14399',
+                },
+                '2015': None
+            },
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'standing_in': {
+                    '2010': {
+                        'name': 'Edinburgh East',
+                        'post_id': '14419',
+                        'mapit_url': 'http://mapit.mysociety.org/area/14419',
+                    },
+                    '2015': {
+                        'name': 'Edinburgh North and Leith',
+                        'post_id': '14420',
+                        'mapit_url': 'http://mapit.mysociety.org/area/14420',
+                    },
+                }
+            }
+        )
+
+    def test_merge_conflicting_names(self):
+        primary = {
+            'name': 'Dave Cameron',
+        }
+        secondary = {
+            'name': 'David Cameron',
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'name': 'Dave Cameron',
+                'other_names': [
+                    {'name': 'David Cameron'}
+                ]
+            }
+        )
+
+    def test_merge_conflicting_names_previous_other_names(self):
+        primary = {
+            'name': 'Dave Cameron',
+            'other_names': [
+                {'name': 'David W D Cameron'}
+            ]
+        }
+        secondary = {
+            'name': 'David Cameron',
+            'other_names': [
+                {'name': 'David William Donald Cameron'}
+            ]
+        }
+        merged = merge_popit_people(primary, secondary)
+        import json
+        self.assertEqual(
+            set(merged.keys()),
+            set(['name', 'other_names'])
+        )
+        self.assertEqual(merged['name'], 'Dave Cameron')
+        sorted_other_names = sorted(
+            merged['other_names'],
+            key=lambda e: e['name']
+        )
+        print json.dumps(sorted_other_names, indent=4)
+        self.assertEqual(
+            sorted_other_names,
+            [
+                {'name': 'David Cameron'},
+                {'name': 'David W D Cameron'},
+                {'name': 'David William Donald Cameron'},
+            ],
+        )
+
+    def test_merge_versions(self):
+        primary = {
+            'name': 'Dave Cameron',
+            'versions': [
+                {
+                    "version_id": "12fdb2d20e9e0753",
+                    "information_source": "Some random update",
+                },
+                {
+                    "version_id": "3570e9e02d2bdf21",
+                    "information_source": "Original import",
+                },
+            ]
+        }
+        secondary = {
+            'name': 'David Cameron',
+            'versions': [
+                {
+                    "version_id": "b6fafb50a424b012",
+                    "information_source": "Creation of a duplicate",
+                },
+            ]
+        }
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {
+                'name': 'Dave Cameron',
+                'other_names': [
+                    {'name': 'David Cameron'}
+                ],
+                'versions': [
+                    {
+                        "version_id": "12fdb2d20e9e0753",
+                        "information_source": "Some random update",
+                    },
+                    {
+                        "version_id": "3570e9e02d2bdf21",
+                        "information_source": "Original import",
+                    },
+                    {
+                        "version_id": "b6fafb50a424b012",
+                        "information_source": "Creation of a duplicate",
+                    },
+                ]
+            }
+        )

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -5,8 +5,8 @@ from django.contrib import admin
 from candidates.views import (ConstituencyPostcodeFinderView,
     ConstituencyNameFinderView, ConstituencyDetailView, CandidacyView,
     CandidacyDeleteView, NewPersonView, UpdatePersonView, RevertPersonView,
-    PersonView, HelpApiView, HelpAboutView, ConstituencyListView,
-    RecentChangesView, LeaderboardView)
+    MergePeopleView, PersonView, HelpApiView, HelpAboutView,
+    ConstituencyListView, RecentChangesView, LeaderboardView)
 from .feeds import RecentChangesFeed
 
 urlpatterns = patterns('',
@@ -32,6 +32,9 @@ urlpatterns = patterns('',
     url(r'^person/(?P<person_id>\d+)/revert$',
         RevertPersonView.as_view(),
         name='person-revert'),
+    url(r'^person/(?P<person_id>\d+)/merge$',
+        MergePeopleView.as_view(),
+        name='person-merge'),
     url(r'^person/(?P<person_id>\d+)(?:/(?P<ignored_slug>.*))?$',
         PersonView.as_view(),
         name='person-view'),

--- a/candidates/views.py
+++ b/candidates/views.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from random import randint
+import re
 import sys
 
 from slugify import slugify
@@ -13,7 +14,7 @@ from django.utils import timezone
 from django.utils.http import urlquote
 from django.views.generic import FormView, TemplateView, View
 
-from braces.views import LoginRequiredMixin
+from braces.views import LoginRequiredMixin, SuperuserRequiredMixin
 
 from .diffs import get_version_diffs
 from .forms import (
@@ -29,7 +30,7 @@ from .models import (
     membership_covers_date, election_date_2010, election_date_2015,
     LoggedAction, PersonRedirect
 )
-from .popit import PopItApiMixin
+from .popit import PopItApiMixin, merge_popit_people
 from .static_data import MapItData, PartyData
 
 from .update import PersonParseMixin, PersonUpdateMixin
@@ -391,6 +392,47 @@ class RevertPersonView(LoginRequiredMixin, CandidacyMixin, PersonParseMixin, Per
             )
         )
 
+class MergePeopleView(SuperuserRequiredMixin, CandidacyMixin, PersonParseMixin, PersonUpdateMixin, View):
+
+    http_method_names = [u'post']
+
+    def post(self, request, *args, **kwargs):
+        # Check that the person IDs are well-formed:
+        primary_person_id = self.kwargs['person_id']
+        secondary_person_id = self.request.POST['other']
+        if not re.search('^\d+$', secondary_person_id):
+            message = "Malformed person ID '{0}'"
+            raise ValueError(message.format(secondary_person_id))
+        if primary_person_id == secondary_person_id:
+            message = "You can't merge a person ({0}) with themself ({1})"
+            raise ValueError(message.format(
+                primary_person_id, secondary_person_id
+            ))
+        # Get our JSON representation of each person:
+        primary_person = self.get_person(primary_person_id)
+        secondary_person = self.get_person(secondary_person_id)
+        # Merge them (which will include a merged versions array):
+        merged_person = merge_popit_people(primary_person, secondary_person)
+        # Update the primary person in PopIt:
+        previous_versions = merged_person.pop('versions')
+        change_metadata = self.get_change_metadata(
+            self.request, 'After merging person {0}'.format(secondary_person_id)
+        )
+        self.update_person(merged_person, change_metadata, previous_versions)
+        # Now we delete the old person:
+        self.api.persons(secondary_person_id).delete()
+        # Create a redirect from the old person to the new person:
+        PersonRedirect.objects.create(
+            old_person_id=secondary_person_id,
+            new_person_id=primary_person_id,
+        )
+        # And redirect to the primary person with the merged data:
+        return HttpResponseRedirect(
+            reverse('person-view', kwargs={
+                'person_id': primary_person_id,
+                'ignored_slug': slugify(primary_person['name']),
+            })
+        )
 
 class UpdatePersonView(LoginRequiredMixin, CandidacyMixin, PersonParseMixin, PersonUpdateMixin, FormView):
     template_name = 'candidates/person-edit.html'


### PR DESCRIPTION
We're making this superuser only, since it's not trivial to revert a
merge in the same way that reverting a change to a field of a person
is.

When you go to a particular person's edit page, that person is
considered the 'primary' person, and the ID that you put into the
edit box is the 'secondary' person. In the case of any conflict
between the data, the field for the primary person is used.

The versions array of the primary person is prepended to the versions
array for the second person, and before them a "merged" version is
prepended. This isn't ideal - really, now that we support merging
you'd want a directed-acyclic graph of versions (like git, say) but I'm
reluctant to reinvent git's data model in a PopIt field.  As it is,
this might be confusing because the order of the versions is no longer
strictly reverse chronological; the first in the versions array will
still always be the most recent, however.