### PR TITLE
Update the EC importer to use openelectoralcommission.org.uk data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /conf/general.yml.deployed
 /conf/httpd.conf
 /conf/httpd.conf.deployed
+/data/party-emblems/

--- a/candidates/management/commands/images.py
+++ b/candidates/management/commands/images.py
@@ -10,4 +10,6 @@ def image_uploaded_already(api_collection, object_id, image_filename):
     for image in person_data.get('images', []):
         if image.get('notes') == 'md5sum:' + md5sum:
             return True
+        elif image.get('md5sum') == md5sum:
+            return True
     return False

--- a/candidates/management/commands/images.py
+++ b/candidates/management/commands/images.py
@@ -1,0 +1,13 @@
+import hashlib
+
+def get_file_md5sum(filename):
+    with open(filename, 'rb') as f:
+        return hashlib.md5(f.read()).hexdigest()
+
+def image_uploaded_already(api_collection, object_id, image_filename):
+    person_data = api_collection(object_id).get()['result']
+    md5sum = get_file_md5sum(image_filename)
+    for image in person_data.get('images', []):
+        if image.get('notes') == 'md5sum:' + md5sum:
+            return True
+    return False


### PR DESCRIPTION
There have been some small changes which required updates:

 * We're now loading the JSON from a URL rather than a submodule

 * The de-registration dates are now in a separate field rather than
   being appended to the party name

 * The format of errors seems to have changed (see
   https://github.com/mysociety/popit-api/issues/113 )

 * Emblem images have to be fetched from
   http://openelectoralcommission.org.uk/party_images/ rather than found
   in the submodule.