### PR TITLE
Add parlparse id to 2010 mps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "UK-Political-Parties"]
 	path = data/UK-Political-Parties
 	url = https://github.com/mhl/UK-Political-Parties.git
+[submodule "data/parlparse"]
+	path = data/parlparse
+	url = https://github.com/mysociety/parlparse.git

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ more instructions for this.)
 Install some required packages:
 
     sudo apt-get install python-virtualenv curl yui-compressor \
-        python-dev libpq-dev
+        python-dev libpq-dev libxml2-dev libxslt-dev
 
 Create a virtualenv with all the Python packages you'll need:
 

--- a/candidates/diffs.py
+++ b/candidates/diffs.py
@@ -125,6 +125,13 @@ def get_version_diff(from_data, to_data):
     result.sort(key=lambda o: (o['op'], o['path']))
     return result
 
+def clean_version_data(data):
+    # We're not interested in changes of these IDs:
+    for i in data.get('identifiers', []):
+        i.pop('id', None)
+    for on in data.get('other_names', []):
+        on.pop('id', None)
+
 def get_version_diffs(versions):
     """Add a diff to each of an array of version dicts
 
@@ -145,6 +152,8 @@ def get_version_diffs(versions):
             #     versions[i + 1]['data']
             # )
             from_version_data = versions[i + 1]['data']
+        clean_version_data(to_version_data)
+        clean_version_data(from_version_data)
         version_with_diff = versions[i].copy()
         version_with_diff['diff'] = \
             get_version_diff(from_version_data, to_version_data)

--- a/candidates/management/commands/candidates_add_parlparse_id.py
+++ b/candidates/management/commands/candidates_add_parlparse_id.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+from django.core.management.base import BaseCommand
+
+import json
+from lxml import objectify
+
+from candidates.popit import create_popit_api_object
+from candidates.update import PersonParseMixin, PersonUpdateMixin
+from candidates.views import CandidacyMixin
+
+CONSTITUENCIES_JSON_FILE = 'data/mapit-WMC-generation-22.json'
+ALL_MEMBERS_XML_FILE = 'data/parlparse/members/all-members-2010.xml'
+PEOPLE_XML_FILE = 'data/parlparse/members/people.xml'
+
+PARTY_MAPPING = {
+    'Alliance': 'Alliance - Alliance Party of Northern Ireland',
+    'Con': 'Conservative Party',
+    'DUP': 'Democratic Unionist Party - D.U.P.',
+    'Green': 'Green Party',
+    'Ind': 'Independent',
+    'LDem': 'Liberal Democrats',
+    'Lab': 'Labour Party',
+    'PC': 'Plaid Cymru - The Party of Wales',
+    'Res': 'The Respect Party',
+    'SDLP': 'SDLP (Social Democratic & Labour Party)',
+    'SF': u'Sinn Féin',
+    'SNP': 'Scottish National Party (SNP)',
+    'SPK': 'Speaker seeking re-election',
+    'UKIP': 'UK Independence Party (UKIP)',
+}
+
+
+class Command(PersonParseMixin, PersonUpdateMixin, CandidacyMixin, BaseCommand):
+    help = "Update candidates' parlparse id"
+
+    def handle(self, *args, **options):
+        self.verbosity = int(options.get('verbosity', 1))
+        self.popit = create_popit_api_object()
+        with open(CONSTITUENCIES_JSON_FILE) as f:
+            constituencies = json.load(f).values()
+        xml = objectify.parse(ALL_MEMBERS_XML_FILE).getroot()
+        self.members = [member.attrib for member in xml.findall('member')]
+        people_xml = objectify.parse(PEOPLE_XML_FILE).getroot()
+        people = people_xml.findall('person')
+        self.id_mapping = {p.get('latestname'): p.get('id') for p in people}
+        self.update_candidates(constituencies)
+
+    def update_candidates(self, constituencies):
+        for constituency in constituencies:
+            for member in self.members_for(constituency['name']):
+                self.add_parlparse_id_to_member(member)
+
+    def members_for(self, constituency_name):
+        constituency_members = []
+        for member in self.members:
+            if member['constituency'] == constituency_name:
+                constituency_members.append(member)
+        return constituency_members
+
+    def add_parlparse_id_to_member(self, member):
+        # Try and find the corresponding person in the popit instance
+        name = u'{} {}'.format(member['firstname'], member['lastname'])
+        query = u'"{}"'.format(name)
+        result = self.popit.api.search.persons.get(q=query)['result']
+        # Have we not got any results?
+        if len(result) == 0:
+            if self.verbosity > 0:
+                msg = u'No results for {}, skipping'
+                self.stderr.write(msg.format(name))
+            return
+        # Find the person with a matching constituency
+        person = self.person_match(member=member, people=result)
+        if not person:
+            if self.verbosity > 0:
+                msg = u'{} result but no matches found for {}'
+                self.stderr.write(msg.format(len(result), name))
+            return
+        parlparse_id = self.id_mapping[name]
+        person_data = self.get_person(person['id'])
+        previous_versions = person_data.pop('versions')
+        identifiers = person_data.get('identifiers', [])
+        existing_identifiers = [i['identifier'] for i in identifiers]
+        # Does that person already have this identifier?
+        if parlparse_id in existing_identifiers:
+            if self.verbosity > 1:
+                msg = u'Found existing identifier for {} ({}), skipping'
+                self.stderr.write(msg.format(name, parlparse_id))
+            return
+        identifier = {
+            'identifier': parlparse_id,
+            'scheme': 'uk.org.publicwhip'
+        }
+        identifiers.append(identifier)
+        person_data['identifiers'] = identifiers
+        change_metadata = self.get_change_metadata(
+            None,
+            'Updated candidate with parlparse person id',
+        )
+        self.update_person(
+            person_data,
+            change_metadata,
+            previous_versions,
+        )
+        if self.verbosity > 0:
+            msg = u"Successfully updated {} with {}"
+            self.stdout.write(msg.format(name, parlparse_id))
+
+    def person_match(self, people, member):
+        match = None
+        for person in people:
+            constituency_name = person.get('standing_in') and \
+                person['standing_in'].get('2010', {}).get('name', '')
+            party_name = person.get('party_memberships') and \
+                person['party_memberships'].get('2010', {}).get('name', '')
+            if constituency_name == member['constituency'] and \
+                    party_name == PARTY_MAPPING[member['party']]:
+                match = person
+                break
+        return match

--- a/candidates/tests/test_version_diffs.py
+++ b/candidates/tests/test_version_diffs.py
@@ -450,3 +450,138 @@ class TestVersionDiffs(TestCase):
         versions_with_diffs = get_version_diffs(versions)
 
         self.assertEqual(expected_result, versions_with_diffs)
+
+    def test_remove_ids_for_version_diffs(self):
+        versions = [
+            {
+                'user': 'john',
+                'information_source': 'Manual correction by a user',
+                'data': {
+                    'identifiers': [
+                        {
+                            'scheme': 'yournextmp-candidate',
+                            'identifier': '2959',
+                            'id': '123456',
+                        },
+                    ],
+                    'other_names': [
+                        {
+                            'note': 'Full name',
+                            'start_date': None,
+                            'id': '567890',
+                            'end_date': None,
+                            'name': 'Tessa Jane Jowell'
+                        }
+                    ]
+                }
+            },
+            {
+                'information_source': 'Updated by a script',
+                'data': {
+                    'identifiers': [
+                        {
+                            'scheme': 'yournextmp-candidate',
+                            'identifier': '2959',
+                            'id': '123457',
+                        }
+                    ],
+                    'other_names': [
+                        {
+                            'note': 'Full name',
+                            'start_date': None,
+                            'id': '567891',
+                            'end_date': None,
+                            'name': 'Tessa J Jowell'
+                        }
+                    ]
+                }
+            },
+        ]
+
+        expected_result = [
+            {
+                'user': 'john',
+                'information_source': 'Manual correction by a user',
+                'data': {
+                    'identifiers': [
+                        {
+                            'scheme': 'yournextmp-candidate',
+                            'identifier': '2959',
+                        },
+                    ],
+                    'other_names': [
+                        {
+                            'note': 'Full name',
+                            'start_date': None,
+                            'end_date': None,
+                            'name': 'Tessa Jane Jowell'
+                        }
+                    ],
+                },
+                'diff': [
+                    {
+                        "op": "replace",
+                        "path": "other_names/0",
+                        "previous_value": {
+                            "end_date": None,
+                            "name": "Tessa J Jowell",
+                            "note": "Full name",
+                            "start_date": None
+                        },
+                        "value": {
+                            "end_date": None,
+                            "name": "Tessa Jane Jowell",
+                            "note": "Full name",
+                            "start_date": None
+                        }
+                    }
+                ],
+            },
+            {
+                'information_source': 'Updated by a script',
+                'data': {
+                    'identifiers': [
+                        {
+                            'scheme': 'yournextmp-candidate',
+                            'identifier': '2959',
+                        },
+                    ],
+                    'other_names': [
+                        {
+                            'note': 'Full name',
+                            'start_date': None,
+                            'end_date': None,
+                            'name': 'Tessa J Jowell'
+                        }
+                    ]
+                },
+                'diff': [
+                    {
+                        "op": "add",
+                        "path": "identifiers",
+                        "value": [
+                            {
+                                "identifier": "2959",
+                                "scheme": "yournextmp-candidate"
+                            }
+                        ]
+                    },
+                    {
+                        "op": "add",
+                        "path": "other_names",
+                        "value": [
+                            {
+                                "end_date": None,
+                                "name": "Tessa J Jowell",
+                                "note": "Full name",
+                                "start_date": None
+                            }
+                        ]
+                    }
+                ],
+            },
+        ]
+
+        versions_with_diffs = get_version_diffs(versions)
+
+        self.assertEqual(expected_result, versions_with_diffs)

--- a/candidates/update.py
+++ b/candidates/update.py
@@ -177,6 +177,7 @@ class PersonParseMixin(PopItApiMixin):
         result['image'] = person.popit_data.get('image')
         result['proxy_image'] = person.popit_data.get('proxy_image')
         result['other_names'] = person.popit_data.get('other_names', [])
+        result['identifiers'] = person.popit_data.get('identifiers', [])
         return result
 
 

--- a/conf/packages
+++ b/conf/packages
@@ -4,3 +4,5 @@ libpq-dev
 python-dev
 opencv-data
 python-opencv
+libxml2-dev
+libxslt-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ ipdb==0.8
 ipython==2.1.0
 jsonpatch==1.9
 jsonpointer==1.6
+lxml==3.4.1
 mock==1.0.1
 nose==1.3.4
 numpy==1.9.1


### PR DESCRIPTION
Iterate over all the MPs from the 2010 election and add their parlparse/publicwhip id as an identifier. This should make it easier to do #144.

Fixes #143 