### PR TITLE
Strip off any leading @ in Twitter username in validation

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -122,10 +122,12 @@ class BasePersonForm(forms.Form):
 
     def clean_twitter_username(self):
         # Remove any URL bits around it:
-        username = self.cleaned_data['twitter_username']
+        username = self.cleaned_data['twitter_username'].strip()
         m = re.search('^.*twitter.com/(\w+)', username)
         if m:
             username = m.group(1)
+        # If there's a leading '@', strip that off:
+        username = re.sub(r'^@', '', username)
         if not re.search(r'^\w*$', username):
             message = "The Twitter username must only consist of alphanumeric characters or underscore"
             raise ValidationError(message)


### PR DESCRIPTION
It's common for people to enter Twitter usernames with a leading '@'
sign, and rejecting this just annoys people - if there's a leading '@',
strip it off and then check that the username only contains valid
characters.