### PR TITLE
Fix spacing above finder form on homepage

### DIFF
--- a/candidates/static/candidates/_finder.scss
+++ b/candidates/static/candidates/_finder.scss
@@ -100,7 +100,7 @@
   .finder__forms {
     position: relative;
     background-color: #fff;
-    margin: -3em auto 0 auto;
+    margin: -5em auto 0 auto;
     padding: 2em 4em 0 4em;
 
     &:before,


### PR DESCRIPTION
The recent merge of the [profile page redesign](https://github.com/mysociety/yournextmp-popit/commit/46d2151eb7d66c7087f8114e0d751255da9ae10c) included the removal of the `.content__inner` div from the base template. The current homepage design expects `.content__inner` to be there, with 2em padding-top. Without it, the homepage form sits too low, and the fake shadows on either side don’t line up.

This would have been fixed by the new homepage layout in #154 but that hasn’t been merged yet. So here’s an interim fix.

Before:

![before](https://cloud.githubusercontent.com/assets/739624/5998507/35b8e7ec-aac0-11e4-8e9b-1b74d9e7ce2f.png)

After:

![after](https://cloud.githubusercontent.com/assets/739624/5998511/3a5e6dd0-aac0-11e4-8654-a93899f35962.png)