### PR TITLE
Add standing again for the same / different party statistics

### DIFF
--- a/cached_counts/templates/reports.html
+++ b/cached_counts/templates/reports.html
@@ -11,10 +11,12 @@
 
 <ul class="total_percent">
     <li>Percent done compared to 2010: {{percent_of_2010|floatformat}}%</li>
-    <li>2010 candidates known: 4,152</li>
+    <li>2010 candidates known: {{candidates_2010|intcomma}}</li>
     <li>2015 candidates known: {{candidates_2015|intcomma}}</li>
     <li>New candidates: {{new_candidates|intcomma}}</li>
     <li>Candidates standing again: {{standing_again|intcomma}}</li>
+    <li>Candidates standing again for the same party: {{standing_again_same_party|intcomma}}</li>
+    <li>Candidates standing again for a different party: {{standing_again_different_party|intcomma}}</li>
     <li><a href="{% url "constituencies_counts" %}">Candidates per constituency</a></li>
     <li><a href="{% url "party_counts" %}">Candidates per party</a></li>
 </ul>

--- a/cached_counts/views.py
+++ b/cached_counts/views.py
@@ -9,23 +9,22 @@ class ReportsHomeView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(ReportsHomeView, self).get_context_data(**kwargs)
-        try:
-            context['candidates_2015'] = CachedCount.objects.get(
-                object_id='candidates_2015').count
-            context['percent_of_2010'] = 100 * float(
-                context['candidates_2015'])/float(4152)
-        except CachedCount.DoesNotExist:
-            pass
-        try:
-            context['new_candidates'] = CachedCount.objects.get(
-                object_id='new_candidates').count
-        except CachedCount.DoesNotExist:
-            pass
-        try:
-            context['standing_again'] = CachedCount.objects.get(
-                object_id='standing_again').count
-        except CachedCount.DoesNotExist:
-            pass
+        for object_id in (
+                'candidates_2015',
+                'candidates_2010',
+                'new_candidates',
+                'standing_again',
+                'standing_again_same_party',
+                'standing_again_different_party',
+        ):
+            try:
+                context[object_id] = CachedCount.objects.get(
+                    object_id=object_id).count
+            except CachedCount.DoesNotExist:
+                pass
+        context['percent_of_2010'] = \
+            (100 * float(context['candidates_2015'])) / \
+            context['candidates_2010']
         return context
 
 class PartyCountsView(ListView):


### PR DESCRIPTION
The statistics on the 'Numbers' page didn't obviously add up (see #185)
and the code that calculated them was a bit difficult to follow if you
wanted to work out why.  This commit hopefully makes their calculation
a bit clearer and also adds statistics to show the breakdown between
candidates who are standing again for the same party or a different party.