### PR TITLE
Add a more prominent link to the API page

### DIFF
--- a/candidates/templates/candidates/finder.html
+++ b/candidates/templates/candidates/finder.html
@@ -55,7 +55,7 @@ it’s a waste of money.</p>
 <div class="finder__description">
   <div class="container">
     <p>At the last election, YourNextMP’s volunteer-sourced database of candidates was found to be at least as accurate as one of the most popular commercial datasets.</p>
-    <p>YourNextMP is the most comprehensive transparently sourced and well-structured database of General Election 2015 candidate data. Get the data now, or help by contributing new candidate details.</p>
+    <p>YourNextMP is the most comprehensive transparently sourced and well-structured database of General Election 2015 candidate data. <a href="{% url 'help-api' %}">Get the data now</a>, or help by contributing new candidate details.</p>
   </div>
 </div>
 


### PR DESCRIPTION
The new homepage is excellent, and is very much worded for people who
want the data in bulk (“Don’t pay for a candidate database…”). So I
think we should perhaps link to the API / csv download page more
prominently.