### PR TITLE
Add middleware to handle errors better if PopIt is down

### DIFF
--- a/candidates/middleware.py
+++ b/candidates/middleware.py
@@ -1,0 +1,16 @@
+from requests.adapters import ConnectionError
+from slumber.exceptions import HttpServerError
+
+from django.shortcuts import render
+
+class PopItDownMiddleware(object):
+
+    def process_exception(self, request, exc):
+        popit_down = False
+        if isinstance(exc, ConnectionError):
+            popit_down = True
+        elif isinstance(exc, HttpServerError) and '503' in unicode(exc):
+            popit_down = True
+        if popit_down:
+            return render(request, 'candidates/popit_down.html', status=503)
+        return None

--- a/candidates/templates/candidates/popit_down.html
+++ b/candidates/templates/candidates/popit_down.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block body_class %}popit-down{% endblock %}
+
+{% block title %}YourNextMP is Temporarily Unavailable{% endblock %}
+
+{% block hero %}
+  <h1>Error</h1>
+{% endblock %}
+
+{% block content %}
+
+<div class="popit-down">
+
+<h2>Sorry, YourNextMP is temporarily unavailable</h2>
+
+<p>This usually means that we're having to do some brief
+maintenance, and the site will be back soon.</p>
+
+</div>
+
+{% endblock %}

--- a/candidates/tests/test_popit_down_middleware.py
+++ b/candidates/tests/test_popit_down_middleware.py
@@ -1,0 +1,28 @@
+from mock import patch
+
+from django_webtest import WebTest
+
+from requests.adapters import ConnectionError
+from slumber.exceptions import HttpServerError
+
+def raise_connection_error(*args, **kwargs):
+    raise ConnectionError()
+
+def raise_http_server_error(*args, **kwargs):
+    raise HttpServerError('Server Error 503: blah blah')
+
+class TestPopItDown(WebTest):
+
+    @patch('candidates.popit.PopIt')
+    def test_constituencies_page_popit_connection_error(self, mock_popit):
+        mock_popit.side_effect = raise_connection_error
+        response = self.app.get('/constituencies', expect_errors=True)
+        self.assertEqual(response.status_code, 503)
+        self.assertIn('YourNextMP is temporarily unavailable', unicode(response))
+
+    @patch('candidates.popit.PopIt')
+    def test_constituencies_page_popit_http_server_error(self, mock_popit):
+        mock_popit.side_effect = raise_http_server_error
+        response = self.app.get('/constituencies', expect_errors=True)
+        self.assertEqual(response.status_code, 503)
+        self.assertIn('YourNextMP is temporarily unavailable', unicode(response))

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -96,6 +96,7 @@ INSTALLED_APPS = (
 SITE_ID = 1
 
 MIDDLEWARE_CLASSES = (
+    'candidates.middleware.PopItDownMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
If PopIt is being restarted, then we currently get a flurry of error
emails and the users hitting the site then see an ugly Internal Server
Error page. This middleware catches ConnectionError (from requests)
and HttpServerError 503 (from slumber) and presents an error page in the
site's style saying the service is temporarily down.

PopIt and YourNextMP are being indepedently monitored by PopIt, so
hopefully this shouldn't affect our awareness of the site being down.

Fixes #126