### PR TITLE
Change canonical URLs to include https://yournextmp.com

### DIFF
--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -5,7 +5,7 @@
 {% load standing %}
 
 {% block extra_head %}
-    <link rel="canonical" href="{% url 'person-view' person.id person.name|slugify %}" />
+    <link rel="canonical" href="{{ canonical_url }}" />
 {% endblock %}
 
 

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -62,10 +62,16 @@ class PersonView(PersonParseMixin, TemplateView):
         context['person'] = person_data
         context['popit_api_url'] = self.get_base_url()
         context['last_cons'] = self.get_last_constituency(person_data)
-        context['redirect_after_login'] = urlquote(
-            reverse('person-view', kwargs={'person_id': person_data['id']})
+        path = reverse(
+            'person-view',
+            kwargs={
+                'person_id': person_data['id'],
+                'ignored_slug': slugify(person_data['name']),
+            }
         )
+        context['redirect_after_login'] = urlquote(path)
         context['versions'] = get_version_diffs(person_data['versions'])
+        context['canonical_url'] = self.request.build_absolute_uri(path)
         return context
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
The rel="canonical" link should begin https://yournextmp.com so that the
old yournextmp.mysociety.org URLs are dropped from search engines; this
commit builds that URL with request.build_absolute_url.

This relies on the domain being correctly set in the sites framework
and request.is_secure() correctly reflecting whether the site's being
accessed over TLS.