### PR TITLE
Catch 404 exceptions from PopIt and make sure 404 is returned

### DIFF
--- a/candidates/middleware.py
+++ b/candidates/middleware.py
@@ -1,6 +1,7 @@
 from requests.adapters import ConnectionError
-from slumber.exceptions import HttpServerError
+from slumber.exceptions import HttpServerError, HttpClientError
 
+from django.http import Http404
 from django.shortcuts import render
 
 class PopItDownMiddleware(object):
@@ -13,4 +14,7 @@ class PopItDownMiddleware(object):
             popit_down = True
         if popit_down:
             return render(request, 'candidates/popit_down.html', status=503)
+        message_404 = 'Client Error 404' in unicode(exc)
+        if isinstance(exc, HttpClientError) and message_404:
+            raise Http404()
         return None

--- a/candidates/tests/test_person_view.py
+++ b/candidates/tests/test_person_view.py
@@ -24,3 +24,11 @@ class TestPersonView(WebTest):
                 unicode(response)
             )
         )
+
+    def test_get_non_existent(self, mock_popit):
+        mock_popit.return_value.persons = FakePersonCollection
+        response = self.app.get(
+            '/person/987654/imaginary-person',
+            expect_errors=True
+        )
+        self.assertEqual(response.status_code, 404)

--- a/candidates/tests/test_person_view.py
+++ b/candidates/tests/test_person_view.py
@@ -1,0 +1,26 @@
+# Smoke tests for viewing a candidate's page
+
+import re
+
+from mock import patch
+
+from django_webtest import WebTest
+
+from .fake_popit import FakePersonCollection
+
+@patch('candidates.popit.PopIt')
+class TestPersonView(WebTest):
+
+    def test_get_tessa_jowell(self, mock_popit):
+        mock_popit.return_value.persons = FakePersonCollection
+        response = self.app.get('/person/2009/tessa-jowell')
+        self.assertTrue(
+            re.search(
+                r'''(?msx)
+  <h1>Tessa\ Jowell</h1>\s*
+  <p>Candidate\ for
+  \ <a\ href="/constituency/65808/dulwich-and-west-norwood">Dulwich
+  \ and\ West\ Norwood</a>\ in\ 2015</p>''',
+                unicode(response)
+            )
+        )


### PR DESCRIPTION
We were getting error emails whenever a crawler tried to fetch a page
for a person who had been deleted, which was annoying. This was because
when slumber got a 404 from PopIt, it would raise a HttpClientError
exception. If we catch this and raise one of Django's Http404 exceptions
we shouldn't get an error email.

Fixes #211