### PR TITLE
Add fields for pre-nominal and post-nominal honorifics

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -71,9 +71,19 @@ class CandidacyDeleteForm(BaseCandidacyForm):
     )
 
 class BasePersonForm(forms.Form):
+    honorific_prefix = forms.CharField(
+        label="Title / pre-nominal honorific (e.g. Dr, Sir, etc.)",
+        max_length=64,
+        required=False,
+    )
     name = forms.CharField(
         label="Full name",
         max_length=256,
+    )
+    honorific_suffix = forms.CharField(
+        label="Post-nominal letters (e.g. CBE, DSO, etc.)",
+        max_length=64,
+        required=False,
     )
     email = forms.EmailField(
         label="Email",

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -15,7 +15,10 @@ from slumber.exceptions import HttpServerError
 
 from .static_data import MapItData
 
-form_simple_fields = ('name', 'email', 'birth_date', 'gender')
+form_simple_fields = (
+    'honorific_prefix', 'name', 'honorific_suffix', 'email', 'birth_date',
+    'gender'
+)
 preserve_fields = ('identifiers', 'other_names', 'phone')
 
 CSV_ROW_FIELDS = [
@@ -37,6 +40,8 @@ CSV_ROW_FIELDS = [
     'birth_date',
     'parlparse_id',
     'theyworkforyou_url',
+    'honorific_prefix',
+    'honorific_suffix',
 ]
 
 
@@ -412,7 +417,9 @@ class PopItPerson(object):
             )
 
         row = {
+            'honorific_prefix': self.popit_data.get('honorific_prefix', ''),
             'name': self.name,
+            'honorific_suffix': self.popit_data.get('honorific_prefix', ''),
             'id': self.id,
             'party': person_data['party_memberships']['2015']['name'],
             'constituency': self.standing_in['2015']['name'],

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -41,7 +41,7 @@
 
   <dl>
     <dt>Name</dt>
-    <dd>{{ person.name }}</dd>
+    <dd>{{ name_with_honorifics }}</dd>
     {% if person.other_names %}
       <dt>Also known as</dt>
     {% endif %}

--- a/candidates/tests/test_create_person.py
+++ b/candidates/tests/test_create_person.py
@@ -15,6 +15,8 @@ EXPECTED_ARGS = {
     'birth_date': None,
     'email': u'jane@example.org',
     'gender': 'female',
+    'honorific_prefix': None,
+    'honorific_suffix': None,
     'id': '1',
     'identifiers': [
         {

--- a/candidates/tests/test_csv_export.py
+++ b/candidates/tests/test_csv_export.py
@@ -22,14 +22,14 @@ class CSVTests(TestCase):
 
     def test_as_dict(self):
         person_dict = self.people[0].as_dict
-        self.assertEqual(len(person_dict), 18)
+        self.assertEqual(len(person_dict), 20)
         self.assertEqual(person_dict['id'], "2959")
 
     def test_csv_output(self):
         example_output = '' + \
-          'name,id,party,constituency,mapit_id,mapit_url,gss_code,twitter_username,facebook_page_url,party_ppc_page_url,gender,facebook_personal_url,email,homepage_url,wikipedia_url,birth_date,parlparse_id,theyworkforyou_url\r\n' + \
-          'Tessa Jowell,2959,Labour Party,Dulwich and West Norwood,65808,http://mapit.mysociety.org/area/65808,E14000673,,,,,,jowell@example.com,,,,uk.org.publicwhip/person/10326,http://www.theyworkforyou.com/mp/10326\r\n' + \
-          'Daith\xc3\xad McKay,1953,Sinn F\xc3\xa9in,North Antrim,66135,http://mapit.mysociety.org/area/66135,N06000012,,,,male,,,,,,,\r\n'
+          'name,id,party,constituency,mapit_id,mapit_url,gss_code,twitter_username,facebook_page_url,party_ppc_page_url,gender,facebook_personal_url,email,homepage_url,wikipedia_url,birth_date,parlparse_id,theyworkforyou_url,honorific_prefix,honorific_suffix\r\n' + \
+          'Tessa Jowell,2959,Labour Party,Dulwich and West Norwood,65808,http://mapit.mysociety.org/area/65808,E14000673,,,,,,jowell@example.com,,,,uk.org.publicwhip/person/10326,http://www.theyworkforyou.com/mp/10326,,\r\n' + \
+          'Daith\xc3\xad McKay,1953,Sinn F\xc3\xa9in,North Antrim,66135,http://mapit.mysociety.org/area/66135,N06000012,,,,male,,,,,,,,,\r\n'
         self.assertEqual(
             list_to_csv([p.as_dict for p in self.people]),
             example_output,

--- a/candidates/tests/test_get_data_for_popit.py
+++ b/candidates/tests/test_get_data_for_popit.py
@@ -28,6 +28,8 @@ class TestGetDataForPopIt(TestCase):
             ],
             'email': u'john@example.org',
             'gender': None,
+            'honorific_prefix': None,
+            'honorific_suffix': None,
             'links': [
                 {
                     'note': 'wikipedia', 'url': 'http://en.wikipedia.org/wiki/John_Doe'
@@ -62,6 +64,8 @@ class TestGetDataForPopIt(TestCase):
             ],
             'email': None,
             'gender': None,
+            'honorific_prefix': None,
+            'honorific_suffix': None,
             'links': [
                 {
                     'note': 'wikipedia', 'url': 'http://en.wikipedia.org/wiki/John_Doe'

--- a/candidates/tests/test_new_person_view.py
+++ b/candidates/tests/test_new_person_view.py
@@ -73,6 +73,8 @@ class TestNewPersonView(TestUserMixin, WebTest):
                 'facebook_personal_url': '',
                 'gender': '',
                 'homepage_url': u'',
+                'honorific_prefix': '',
+                'honorific_suffix': '',
                 'linkedin_url': u'',
                 'name': u'Jane Doe',
                 'party_memberships': {

--- a/candidates/tests/test_update_person.py
+++ b/candidates/tests/test_update_person.py
@@ -77,6 +77,8 @@ class TestUpdatePerson(TestCase):
                 'contact_details': [],
                 'email': u'foo@example.org',
                 'gender': None,
+                'honorific_prefix': None,
+                'honorific_suffix': None,
                 'name': u'Tessa Jowell',
                 'links': [],
                 'other_names': [],
@@ -102,6 +104,8 @@ class TestUpdatePerson(TestCase):
                 ],
                 'email': u'foo@example.org',
                 'gender': None,
+                'honorific_prefix': None,
+                'honorific_suffix': None,
                 'name': u'Tessa Jowell',
                 'links': [
                     {

--- a/candidates/tests/test_update_view.py
+++ b/candidates/tests/test_update_view.py
@@ -67,6 +67,8 @@ class TestUpdatePersonView(TestUserMixin, WebTest):
                 'facebook_personal_url': '',
                 'gender': '',
                 'homepage_url': '',
+                'honorific_prefix': '',
+                'honorific_suffix': '',
                 'id': '2009',
                 'linkedin_url': '',
                 'name': 'Tessa Jowell',

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -57,6 +57,17 @@ class PersonView(PersonParseMixin, TemplateView):
                 result = (year, cons)
         return result
 
+    def get_name_with_honorifics(self, person_data):
+        name_parts = []
+        pre = person_data.get('honorific_prefix')
+        post = person_data.get('honorific_suffix')
+        if pre:
+            name_parts.append(pre)
+        name_parts.append(person_data.get('name', ''))
+        if post:
+            name_parts.append(post)
+        return ' '.join(name_parts)
+
     def get_context_data(self, **kwargs):
         context = super(PersonView, self).get_context_data(**kwargs)
         person_data, extra_for_template = self.get_person(self.kwargs['person_id'])
@@ -74,6 +85,8 @@ class PersonView(PersonParseMixin, TemplateView):
         context['redirect_after_login'] = urlquote(path)
         context['versions'] = get_version_diffs(person_data['versions'])
         context['canonical_url'] = self.request.build_absolute_uri(path)
+        context['name_with_honorifics'] = \
+            self.get_name_with_honorifics(person_data)
         return context
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Some people have been adding titles like "Cllr" into their names; this
isn't good since most people don't have titles added, and ideally we'd
like to keep them separate.  The Popolo spec suggests honorific_prefix
and honorific_suffix for titles and post-nominal letters:

  http://www.popoloproject.com/specs/person/name-component.html

This commit adds optional fields for these.

To avoid breaking CSV parsers that only look for column number (rather
than the field names in column headers) these are added to the end of
each row.