### PR TITLE
Update photo upload copy to match policy

### DIFF
--- a/candidates/templates/candidates/person-edit.html
+++ b/candidates/templates/candidates/person-edit.html
@@ -16,7 +16,12 @@
       <form id="person-details" action="{% url 'person-update' person_id=person.id %}" method="post">
         {% csrf_token %}
         {{ form.as_p }}
-        <p>Trying to upload a photo?  Please email <a href="mailto:yournextmp@mysociety.org">yournextmp@mysociety.org</a> and we'll upload it for you.</p>
+        <p>
+          Trying to upload a photo?  If you’re the candidate or an agent of
+          the candidate, please email
+          <a href="mailto:yournextmp@mysociety.org">yournextmp@mysociety.org</a>
+          and we'll upload it for you.
+        </p>
         <input type="submit" class="button" value="Save changes">
       </form>
     </div>


### PR DESCRIPTION
I’ve been trying to stick to this policy for photo upload:

> for cases where someone isn't the candidate or their agent, or hasn't indicated that it's known to be public domain or from an official candidate website, i've been ignoring them until the photo upload form is deployed
> — _(from the Slack logs)_

This PR makes that policy a bit more transparent to editors.