### PR TITLE
Make the choices of why photos are allowed mutually exclusive

### DIFF
--- a/moderation_queue/forms.py
+++ b/moderation_queue/forms.py
@@ -10,12 +10,13 @@ class UploadPersonPhotoForm(forms.ModelForm):
     class Meta:
         model = QueuedImage
         fields = [
-            'image', 'public_domain', 'use_allowed_by_owner',
+            'image', 'why_allowed',
             'justification_for_use', 'popit_person_id', 'decision'
         ]
         widgets = {
             'popit_person_id': forms.HiddenInput(),
             'decision': forms.HiddenInput(),
+            'why_allowed': forms.RadioSelect(),
             'justification_for_use': forms.Textarea(
                 attrs={'rows': 1, 'columns': 72}
             )
@@ -29,13 +30,13 @@ class UploadPersonPhotoForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super(UploadPersonPhotoForm, self).clean()
-        public_domain = cleaned_data.get('public_domain')
-        use_allowed_by_owner = cleaned_data.get('use_allowed_by_owner')
-        definitely_allowed = public_domain or use_allowed_by_owner
-        justification_for_use = cleaned_data.get('justification_for_use', '').strip()
-        if not (justification_for_use or definitely_allowed):
-            message = "If the photo isn't public domain or owned by you, " + \
-                "then you must provide a justification for why we can use it."
+        justification_for_use = cleaned_data.get(
+            'justification_for_use', ''
+        ).strip()
+        why_allowed = cleaned_data.get('why_allowed')
+        if why_allowed == 'other' and not justification_for_use:
+            message = "If you checked 'Other' then you must provide a " + \
+                "justification for why we can use it."
             raise ValidationError(message)
         return cleaned_data
 

--- a/moderation_queue/migrations/0004_queuedimage_why_allowed.py
+++ b/moderation_queue/migrations/0004_queuedimage_why_allowed.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('moderation_queue', '0003_auto_20150301_2035'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='queuedimage',
+            name='why_allowed',
+            field=models.CharField(default=b'other', max_length=64, choices=[(b'public-domain', b'This photograph is free of any copyright restrictions'), (b'copyright-assigned', b'I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on YourNextMP'), (b'profile-photo', b"This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page")]),
+            preserve_default=True,
+        ),
+    ]

--- a/moderation_queue/migrations/0005_migrate_data_to_why_allowed.py
+++ b/moderation_queue/migrations/0005_migrate_data_to_why_allowed.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+def forward_to_why_allowed(apps, schema_editor):
+    QueuedImage = apps.get_model('moderation_queue', 'QueuedImage')
+    for qi in QueuedImage.objects.all():
+        if qi.public_domain:
+            qi.why_allowed = 'public-domain'
+        elif qi.use_allowed_by_owner:
+            qi.why_allowed = 'copyright-assigned'
+        else:
+            qi.why_allowed = 'other'
+        qi.save()
+
+def backwards_from_why_allowed(apps, schema_editor):
+    QueuedImage = apps.get_model('moderation_queue', 'QueuedImage')
+    for qi in QueuedImage.objects.all():
+        if qi.why_allowed == 'public-domain':
+            qi.public_domain = True
+        elif qi.why_allowed == 'copyright-assigned':
+            qi.use_allowed_by_owner = True
+        qi.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('moderation_queue', '0004_queuedimage_why_allowed'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            forward_to_why_allowed,
+            backwards_from_why_allowed,
+        )
+    ]

--- a/moderation_queue/migrations/0006_auto_20150303_0838.py
+++ b/moderation_queue/migrations/0006_auto_20150303_0838.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('moderation_queue', '0005_migrate_data_to_why_allowed'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='queuedimage',
+            name='public_domain',
+        ),
+        migrations.RemoveField(
+            model_name='queuedimage',
+            name='use_allowed_by_owner',
+        ),
+    ]

--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -16,8 +16,31 @@ class QueuedImage(models.Model):
         (UNDECIDED, 'Undecided'),
     )
 
-    public_domain = models.BooleanField(default=False)
-    use_allowed_by_owner = models.BooleanField(default=False)
+    PUBLIC_DOMAIN = 'public-domain'
+    COPYRIGHT_ASSIGNED = 'copyright-assigned'
+    PROFILE_PHOTO = 'profile-photo'
+    OTHER = 'other'
+
+    WHY_ALLOWED_CHOICES = (
+        (PUBLIC_DOMAIN,
+         "This photograph is free of any copyright restrictions"),
+        (COPYRIGHT_ASSIGNED,
+         "I own copyright of this photo and I assign the copyright " + \
+         "to Democracy Club Limited in return for it being displayed " + \
+         "on YourNextMP"),
+        (PROFILE_PHOTO,
+         "This is the candidate's public profile photo from social " + \
+         "media (e.g. Twitter, Facebook) or their official campaign " + \
+         "page"),
+        (OTHER,
+         "Other"),
+    )
+
+    why_allowed = models.CharField(
+        max_length=64,
+        choices=WHY_ALLOWED_CHOICES,
+        default=OTHER,
+    )
     justification_for_use = models.TextField(blank=True)
     decision = models.CharField(
         max_length=32,

--- a/moderation_queue/static/moderation_queue/css/.gitignore
+++ b/moderation_queue/static/moderation_queue/css/.gitignore
@@ -1,1 +1,2 @@
 /crop.css
+/photo-upload.css

--- a/moderation_queue/static/moderation_queue/css/photo-upload.scss
+++ b/moderation_queue/static/moderation_queue/css/photo-upload.scss
@@ -1,0 +1,3 @@
+ul#id_why_allowed {
+  list-style-type: none;
+}

--- a/moderation_queue/templates/moderation_queue/_photo-upload-form.html
+++ b/moderation_queue/templates/moderation_queue/_photo-upload-form.html
@@ -8,21 +8,12 @@
   <p>
     {{ form.image }}
   </p>
-  <p>Now let us know about the copyright of this image by selecting of
+  <p>Now let us know about the copyright of this image by selecting one of
    these options or explaining why we can use it:</p>
-  <p>
-    {{ form.public_domain.errors }}
-    {{ form.public_domain }}
-    <label for="{{ form.public_domain.id_for_label }}">This photograph is free
-      of copyright restrictions (e.g. in the public domain):</label>
-  </p>
-  <p>
-    {{ form.use_allowed_by_owner.errors }}
-    {{ form.use_allowed_by_owner }}
-    <label for="{{ form.use_allowed_by_owner.id_for_label }}">I own copyright
-      of this photo and I assign the copyright to Democracy Club in return for
-      it being displayed on YourNextMP:</label>
-  </p>
+  <div class="photo-why-allowed-radio-buttons">
+    {{ form.why_allowed.errors }}
+    {{ form.why_allowed }}
+  </div>
   <p>
     {{ form.justification_for_use.errors }}
     <label for="{{ form.justification_for_use.id_for_label }}">Here is my

--- a/moderation_queue/templates/moderation_queue/photo-review.html
+++ b/moderation_queue/templates/moderation_queue/photo-review.html
@@ -68,24 +68,31 @@ Image search</a> may be a good start.</p>
 
   <h3>User-submitted information</h3>
 
-  {% if public_domain %}
-    <p>
-      The photo is free of copyright restriction (e.g. in the public domain)
-    </p>
-  {% endif %}
+  {% with username=queued_image.user.username %}
 
-  {% if use_allowed_by_owner %}
-    <p>
-      The user assigned the copyright to Democracy Club
-    </p>
-  {% endif %}
+    {% if why_allowed == 'public-domain' %}
+      <p>
+        {{ username }} asserted that photo is free of copyright restrictions
+      </p>
+    {% elif why_allowed == 'copyright-assigned' %}
+      <p>
+        {{ username }} assigned the copyright to Democracy Club
+      </p>
+    {% elif why_allowed == 'profile-photo' %}
+      <p>
+        {{ username }} said that this is the candidate's public profile
+        photo from social media or their official campaign page
+      </p>
+    {% endif %}
 
-  {% if justification_for_use %}
-    <p>
-      The user's justification for use of this photo was:
-      &#8220;{{ justification_for_use }}&#8221;
-    </p>
-  {% endif %}
+    {% if justification_for_use %}
+      <p>
+        {{ username }}'s justification for use of this photo was:
+        &#8220;{{ justification_for_use }}&#8221;
+      </p>
+    {% endif %}
+
+  {% endwith %}
 
   <h3>Your decision</h3>
 

--- a/moderation_queue/templates/moderation_queue/photo-upload-new.html
+++ b/moderation_queue/templates/moderation_queue/photo-upload-new.html
@@ -4,6 +4,12 @@
 
 {% block title %}Upload a candidate photo{% endblock %}
 
+{% load compressed %}
+
+{% block extra_css %}
+{% compressed_css 'image-review' %}
+{% endblock %}
+
 {% block hero %}
   <h1>Upload a photo of {{ person.name }}</h1>
 {% endblock %}

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -31,8 +31,7 @@ class PhotoReviewTests(WebTest):
             'alsonotagoodpassword',
         )
         self.q1 = QueuedImage.objects.create(
-            public_domain=True,
-            use_allowed_by_owner=False,
+            why_allowed='public-domain',
             justification_for_use="Here's why I believe it's public domain",
             decision='undecided',
             image='pilot.jpg',
@@ -40,8 +39,7 @@ class PhotoReviewTests(WebTest):
             user=self.test_upload_user
         )
         self.q2 = QueuedImage.objects.create(
-            public_domain=False,
-            use_allowed_by_owner=True,
+            why_allowed='copyright-assigned',
             justification_for_use="I took this last week",
             decision='approved',
             image='pilot.jpg',
@@ -49,8 +47,7 @@ class PhotoReviewTests(WebTest):
             user=self.test_upload_user
         )
         self.q3 = QueuedImage.objects.create(
-            public_domain=False,
-            use_allowed_by_owner=False,
+            why_allowed='other',
             justification_for_use="I found it somewhere",
             decision='rejected',
             image='pilot.jpg',
@@ -185,10 +182,8 @@ class PhotoReviewTests(WebTest):
             post_call_kwargs['data'],
             {'justification_for_use':
              u"Here's why I believe it's public domain",
-             'use_allowed_by_owner':
-             u'False',
              'notes': 'Approved from photo moderation queue',
-             'public_domain': u'True',
+             'why_allowed': u'public-domain',
              'uploaded_by_user': u'john',
              'mime_type': 'image/jpeg'}
         )

--- a/moderation_queue/tests/test_upload.py
+++ b/moderation_queue/tests/test_upload.py
@@ -40,7 +40,7 @@ class PhotoUploadTests(WebTest):
         form = form_page_response.forms['person-upload-photo']
         with open(image_filename) as f:
             form['image'] = Upload('pilot.jpg', f.read())
-        form['use_allowed_by_owner'] = True
+        form['why_allowed'] = 'copyright-assigned'
         form['justification_for_use'] = 'I took this photo'
         upload_response = form.submit()
         self.assertEqual(upload_response.status_code, 302)
@@ -50,8 +50,7 @@ class PhotoUploadTests(WebTest):
         self.assertEqual(1, queued_images.count())
         queued_image = list(queued_images)[0]
         self.assertEqual(queued_image.decision, 'undecided')
-        self.assertTrue(queued_image.use_allowed_by_owner)
-        self.assertFalse(queued_image.public_domain)
+        self.assertEqual(queued_image.why_allowed, 'copyright-assigned')
         self.assertEqual(
             queued_image.justification_for_use,
             'I took this photo'

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -123,8 +123,7 @@ class PhotoReview(StaffuserRequiredMixin, PersonParseMixin, PersonUpdateMixin, T
                 'decision': self.queued_image.decision,
             }
         )
-        context['public_domain'] = self.queued_image.public_domain
-        context['use_allowed_by_owner'] = self.queued_image.use_allowed_by_owner
+        context['why_allowed'] = self.queued_image.why_allowed
         context['justification_for_use'] = self.queued_image.justification_for_use
         context['google_image_search_url'] = self.get_google_image_search_url(
             context['person'], context['person_extra']
@@ -151,13 +150,12 @@ class PhotoReview(StaffuserRequiredMixin, PersonParseMixin, PersonUpdateMixin, T
             person_id=self.queued_image.popit_person_id
         )
         data = {
-            k: unicode(getattr(self.queued_image, k))
-            for k in
-            ('public_domain', 'use_allowed_by_owner', 'justification_for_use')
+            'why_allowed': self.queued_image.why_allowed,
+            'justification_for_use': self.queued_image.justification_for_use,
+            'mime_type': PILLOW_FORMAT_MIME_TYPES[original.format],
+            'notes': 'Approved from photo moderation queue',
+            'uploaded_by_user': self.queued_image.user.username,
         }
-        data['mime_type'] = PILLOW_FORMAT_MIME_TYPES[original.format]
-        data['notes'] = 'Approved from photo moderation queue'
-        data['uploaded_by_user'] = self.queued_image.user.username
         with open(ntf.name) as f:
             requests.post(
                 image_upload_url,

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -199,6 +199,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'moderation_queue/css/jquery.Jcrop.css',
             'moderation_queue/css/crop.scss',
+            'moderation_queue/css/photo-upload.scss',
         ),
         'output_filename': 'css/image-review.css',
     },


### PR DESCRIPTION
People seemed to be sometimes checking all of the boxes without
understanding what they meant, since some are mutually exclusive.

This commit switches the BooleanField fields in the model for why a
photo should be allowed to be used for a CharField with defined
choices.

It also removes use of the phrase "public domain" from the text
the user sees, since that's apparently widely misunderstood.

The photo upload form now looks like:

![new-photo-upload](https://cloud.githubusercontent.com/assets/7907/6460395/d07a784c-c18e-11e4-86eb-424ae7adc48a.png)

(although i've now fixed the "selection of these options" typo)

Fixes #228 