### PR TITLE
Ask authenticated users to agree to copyright assignment

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from .mapit import get_wmc_from_postcode, BaseMapItException
+from .models import UserTermsAgreement
 
 class PostcodeForm(forms.Form):
     postcode = forms.CharField(
@@ -261,3 +262,21 @@ class UpdatePersonForm(BasePersonForm):
         if cleaned_data['standing'] == 'standing':
             return self.check_party_and_constituency_are_selected(cleaned_data)
         return cleaned_data
+
+class UserTermsAgreementForm(forms.Form):
+
+    assigned_to_dc = forms.BooleanField(required=False)
+    next_path = forms.CharField(
+        max_length=512,
+        widget=forms.HiddenInput(),
+    )
+
+    def clean_assigned_to_dc(self):
+        assigned_to_dc = self.cleaned_data['assigned_to_dc']
+        if not assigned_to_dc:
+            message = (
+                "You can only edit data on YourNextMP if you agree to "
+                "this copyright assignment."
+            )
+            raise ValidationError(message)
+        return assigned_to_dc

--- a/candidates/middleware.py
+++ b/candidates/middleware.py
@@ -1,8 +1,12 @@
+import re
+
 from requests.adapters import ConnectionError
 from slumber.exceptions import HttpServerError, HttpClientError
 
-from django.http import Http404
+from django.core.urlresolvers import reverse
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
+from django.utils.http import urlquote
 
 class PopItDownMiddleware(object):
 
@@ -18,3 +22,38 @@ class PopItDownMiddleware(object):
         if isinstance(exc, HttpClientError) and message_404:
             raise Http404()
         return None
+
+
+class CopyrightAssignmentMiddleware(object):
+    """Check that authenticated users have agreed to copyright assigment
+
+    This must come after AuthenticationMiddleware so that request.user
+    is present.
+
+    If this is an authenticated user, then insist that they agree to
+    assign copyright of any conributions to Democracy Club
+    """
+
+    EXCLUDED_PATHS = (
+        re.compile(r'^/copyright-question'),
+        re.compile(r'^/accounts/'),
+        re.compile(r'^/admin/'),
+    )
+
+    def process_request(self, request):
+        for path_re in self.EXCLUDED_PATHS:
+            if path_re.search(request.path):
+                return None
+        if not request.user.is_authenticated():
+            return None
+        already_assigned = request.user.terms_agreement.assigned_to_dc
+        if already_assigned:
+            return None
+        else:
+            # Then redirect to a view that asks you to assign
+            # copyright:
+            assign_copyright_url = reverse('ask-for-copyright-assignment')
+            assign_copyright_url += "?next={0}".format(
+                urlquote(request.path)
+            )
+            return HttpResponseRedirect(assign_copyright_url)

--- a/candidates/migrations/0002_usertermsagreement.py
+++ b/candidates/migrations/0002_usertermsagreement.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('candidates', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserTermsAgreement',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('assigned_to_dc', models.BooleanField(default=False)),
+                ('user', models.OneToOneField(related_name='terms_agreement', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/candidates/migrations/0003_create_user_terms_agreements.py
+++ b/candidates/migrations/0003_create_user_terms_agreements.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def create_user_terms_agreements(apps, schema_editor):
+    User = apps.get_model('auth', 'User')
+    UserTermsAgreement = apps.get_model('candidates', 'UserTermsAgreement')
+    for u in User.objects.all():
+        UserTermsAgreement.objects.get_or_create(user=u)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0002_usertermsagreement'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_user_terms_agreements
+        )
+    ]

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -591,3 +591,8 @@ class PersonRedirect(models.Model):
     after two people are merged'''
     old_person_id = models.IntegerField()
     new_person_id = models.IntegerField()
+
+
+class UserTermsAgreement(models.Model):
+    user = models.OneToOneField(User, related_name='terms_agreement')
+    assigned_to_dc = models.BooleanField(default=False)

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -10,6 +10,7 @@ from slugify import slugify
 
 from django.contrib.auth.models import User
 from django.db import models
+from django.db.models.signals import post_save
 from django.core.exceptions import ObjectDoesNotExist
 from slumber.exceptions import HttpServerError
 
@@ -596,3 +597,10 @@ class PersonRedirect(models.Model):
 class UserTermsAgreement(models.Model):
     user = models.OneToOneField(User, related_name='terms_agreement')
     assigned_to_dc = models.BooleanField(default=False)
+
+
+def create_user_terms_agreement(sender, instance, created, **kwargs):
+    if created:
+        UserTermsAgreement.objects.create(user=instance)
+
+post_save.connect(create_user_terms_agreement, sender=User)

--- a/candidates/static/candidates/_copyright-assignment.scss
+++ b/candidates/static/candidates/_copyright-assignment.scss
@@ -1,0 +1,17 @@
+.agreement {
+  label {
+    font-size: 1rem;
+  }
+}
+
+ul.errorlist {
+  margin-left: 0;
+  li {
+    list-style-type: none;
+    color: red;
+  }
+}
+
+.further-copyright-explanation {
+  margin-top: 3em;
+}

--- a/candidates/static/candidates/style.scss
+++ b/candidates/static/candidates/style.scss
@@ -59,3 +59,4 @@ pre {
 @import "versions";
 @import "parties";
 @import "person_edit";
+@import "copyright-assignment";

--- a/candidates/templates/candidates/ask-for-copyright-assignment.html
+++ b/candidates/templates/candidates/ask-for-copyright-assignment.html
@@ -1,0 +1,63 @@
+{% extends 'base.html' %}
+
+{% block body_class %}{% endblock %}
+
+{% block title %}YourNextMP user agreement{% endblock %}
+
+{% block hero %}
+  <h1>YourNextMP user agreement</h1>
+{% endblock %}
+
+{% block content %}
+
+<p>Before you carry on to edit data in YourNextMP, we need you to
+  agree that your contributions to this site (with the exception of
+  photo uploads) are owned by Democracy Club Limited. In return, we
+  agree to make the complete database available under an open licence
+  such as
+  <a href="http://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>
+  or remove copyright restrictions by releasing into the public domain
+  (<a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>).
+  </p>
+
+<form method="post" action="">
+  {% csrf_token %}
+  {{ form.next_path }}
+  <p class="agreement">
+  {{ form.assigned_to_dc.errors }}
+  {{ form.assigned_to_dc }}
+    <label for="{{ form.assigned_to_dc.id_for_label }}">
+      <strong>Yes, I agree to assign the copyright of my contributions
+      to YourNextMP (apart from photo uploads) to Democracy Club
+      Limited.</strong>
+    </label>
+  </p>
+  <input type="submit" class="button" value="Continue" />
+</form>
+
+<p>Otherwise you can
+  <a href="{% url 'account_logout' %}?next={{ next_path_escaped }}">log
+  out</a>. Please do <a href="mailto:yournextmp@mysociety.org">email us</a>
+  if you have any questions about this agreement.</p>
+
+<div class="further-copyright-explanation">
+
+  <h4>Why are we asking you to agree to this?</h4>
+
+  <p>When we originally set up YourNextMP for the 2015 general
+    election we didn't get legal advice about the best way to deal
+    with copyright and licensing. It turns out that the way that the
+    user agreement that was worded on the 'About' page had a few
+    problems, and in particular restricted what we could do with the
+    data such that we couldn't license the database to some partners
+    who we thought would make good use of the data but who needed
+    slightly different licensing. The simplest way to ensure that we
+    can make the data as widely available as possible while preventing
+    the hard work of contributors to YourNextMP being co-opted by
+    companies building closed candidate databases is to ask you to
+    assign the copyright of your contributions to Democracy Club.
+  </p>
+
+</div>
+
+{% endblock %}

--- a/candidates/tests/auth.py
+++ b/candidates/tests/auth.py
@@ -9,7 +9,16 @@ class TestUserMixin(object):
             'john@example.com',
             'notagoodpassword',
         )
+        terms = cls.user.terms_agreement
+        terms.assigned_to_dc = True
+        terms.save()
+        cls.user_refused = User.objects.create_user(
+            'johnrefused',
+            'johnrefused@example.com',
+            'notagoodpasswordeither',
+        )
 
     @classmethod
     def tearDownClass(cls):
+        cls.user_refused.delete()
         cls.user.delete()

--- a/candidates/tests/test_new_person_view.py
+++ b/candidates/tests/test_new_person_view.py
@@ -25,6 +25,33 @@ class TestNewPersonView(TestUserMixin, WebTest):
     @patch('candidates.views.version_data.get_current_timestamp')
     @patch('candidates.views.version_data.create_version_id')
     @patch('candidates.views.people.NewPersonView.create_person')
+    def test_new_person_submission_refused_copyright(
+            self,
+            mock_create_person,
+            mock_create_version_id,
+            mock_get_current_timestamp,
+            mock_popit):
+        # Get the constituency page:
+        mock_popit.return_value.organizations = FakeOrganizationCollection
+        mock_popit.return_value.persons = FakePersonCollection
+        # Just a smoke test for the moment:
+        response = self.app.get(
+            '/constituency/65808/dulwich-and-west-norwood',
+            user=self.user_refused
+        )
+        split_location = urlsplit(response.location)
+        self.assertEqual(
+            '/copyright-question',
+            split_location.path
+        )
+        self.assertEqual(
+            'next=/constituency/65808/dulwich-and-west-norwood',
+            split_location.query
+        )
+
+    @patch('candidates.views.version_data.get_current_timestamp')
+    @patch('candidates.views.version_data.create_version_id')
+    @patch('candidates.views.people.NewPersonView.create_person')
     def test_new_person_submission(
             self,
             mock_create_person,

--- a/candidates/tests/test_terms_agreement.py
+++ b/candidates/tests/test_terms_agreement.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+
+from django.contrib.auth.models import User
+
+class Test(TestCase):
+
+    def test_user_creation_creates_terms_agreement(self):
+        u = User.objects.create_user(
+            'john',
+            'john@example.com',
+            'notagoodpassword',
+        )
+        self.assertFalse(u.terms_agreement.assigned_to_dc)

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -9,7 +9,8 @@ from candidates.views import (ConstituencyPostcodeFinderView,
     CandidacyDeleteView, NewPersonView, UpdatePersonView, RevertPersonView,
     MergePeopleView, PersonView, PartyDetailView, PartyListView,
     HelpApiView, HelpAboutView,
-    ConstituencyListView, RecentChangesView, LeaderboardView)
+    ConstituencyListView, RecentChangesView, LeaderboardView,
+    AskForCopyrightAssigment)
 from .feeds import RecentChangesFeed
 
 urlpatterns = patterns('',
@@ -64,5 +65,8 @@ urlpatterns = patterns('',
     url(r'^help/privacy',
         TemplateView.as_view(template_name="candidates/privacy.html"),
         name='help-privacy'),
+    url(r'^copyright-question',
+        AskForCopyrightAssigment.as_view(),
+        name='ask-for-copyright-assignment'),
     url(r'^admin/', include(admin.site.urls)),
 )

--- a/candidates/views/__init__.py
+++ b/candidates/views/__init__.py
@@ -1,3 +1,4 @@
+from .agreement import *
 from .candidacies import *
 from .constituencies import *
 from .frontpage import *

--- a/candidates/views/agreement.py
+++ b/candidates/views/agreement.py
@@ -1,0 +1,30 @@
+from django.views.generic import FormView
+from django.http import HttpResponseRedirect
+from django.utils.http import urlquote
+from urlparse import urlparse
+
+from ..forms import UserTermsAgreementForm
+
+class AskForCopyrightAssigment(FormView):
+
+    form_class = UserTermsAgreementForm
+    template_name = 'candidates/ask-for-copyright-assignment.html'
+
+    def get_initial(self):
+        initial = super(AskForCopyrightAssigment, self).get_initial().copy()
+        next_url = self.request.GET['next']
+        parsed_url = urlparse(next_url)
+        initial['next_path'] = parsed_url.path
+        return initial
+
+    def form_valid(self, form):
+        ta = self.request.user.terms_agreement
+        ta.assigned_to_dc = True
+        ta.save()
+        return HttpResponseRedirect(form.cleaned_data['next_path'])
+
+    def get_context_data(self, **kwargs):
+        context = super(AskForCopyrightAssigment, self) \
+            .get_context_data(**kwargs)
+        context['next_path_escaped'] = urlquote(self.request.GET['next'])
+        return context

--- a/candidates/views/mixins.py
+++ b/candidates/views/mixins.py
@@ -5,8 +5,11 @@ import sys
 from datetime import timedelta
 
 from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
 from django.db.models import Count
+from django.http import HttpResponseRedirect
 from django.utils import timezone
+from django.utils.http import urlquote
 
 from .version_data import create_version_id, get_current_timestamp
 from ..models import LoggedAction

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -25,11 +25,15 @@ class PhotoReviewTests(WebTest):
             'john@example.com',
             'notagoodpassword',
         )
+        self.test_upload_user.terms_agreement.assigned_to_dc = True
+        self.test_upload_user.terms_agreement.save()
         self.test_superuser = User.objects.create_superuser(
             'jane',
             'jane@example.com',
             'alsonotagoodpassword',
         )
+        self.test_superuser.terms_agreement.assigned_to_dc = True
+        self.test_superuser.terms_agreement.save()
         self.q1 = QueuedImage.objects.create(
             why_allowed='public-domain',
             justification_for_use="Here's why I believe it's public domain",

--- a/moderation_queue/tests/test_upload.py
+++ b/moderation_queue/tests/test_upload.py
@@ -23,6 +23,8 @@ class PhotoUploadTests(WebTest):
             'john@example.com',
             'notagoodpassword',
         )
+        self.test_upload_user.terms_agreement.assigned_to_dc = True
+        self.test_upload_user.terms_agreement.save()
 
     @override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT)
     @patch('candidates.popit.PopIt')

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -3,6 +3,7 @@ import requests
 from tempfile import NamedTemporaryFile
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
@@ -32,6 +33,7 @@ PILLOW_FORMAT_MIME_TYPES = {
 }
 
 
+@login_required
 def upload_photo(request, popit_person_id):
     if request.method == 'POST':
         form = UploadPersonPhotoForm(request.POST, request.FILES)

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -105,6 +105,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'candidates.middleware.CopyrightAssignmentMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )


### PR DESCRIPTION
As part of our plan to make sure that the licensing of the YourNextMP
database is clear, we've been recommended to ask for copyright
assignment from contributors.

This pull request introduces changes such that authenticated users
won't be able to view pages unless they either:
* Agree to the copyright assignnment
* or Log out

The text of the copyright assignment agreement is currently:

---

### YourNextMP user agreement

Before you carry on to edit data in YourNextMP, we need you to agree that your contributions to this site (with the exception of photo uploads) are owned by Democracy Club Limited. In return, we agree to make the complete database available under an open licence such as CC-BY-SA or remove copyright restrictions by releasing into the public domain (CC0).

❏ **Yes, I agree to assign the copyright of my contributions to YourNextMP (apart from photo uploads) to Democracy Club Limited.**

#### Why are we asking you to agree to this?

When we originally set up YourNextMP for the 2015 general election we didn't get legal advice about the best way to deal with copyright and licensing. It turns out that the way that the user agreement that was worded on the 'About' page had a few problems, and in particular restricted what we could do with the data such that we couldn't license the database to some partners who we thought would make good use of the data but who needed slightly different licensing. The simplest way to ensure that we can make the data as widely available as possible while preventing the hard work of contributors to YourNextMP being co-opted by companies building closed candidate databases is to ask you to assign the copyright of your contributions to Democracy Club.

---

A screenshot of this page is here (with slightly out of date text now):

![ynmp-copyright-agreement](https://cloud.githubusercontent.com/assets/7907/6481831/8d5ce192-c258-11e4-88ef-7bcdcf38feb0.png)

Fixes #69 