### PR TITLE
Update "About" page now we have a better contributor agreement

### DIFF
--- a/candidates/templates/candidates/about.html
+++ b/candidates/templates/candidates/about.html
@@ -34,8 +34,9 @@ of known bugs</a> there as well.</p>
 Burg's <a href="http://www.yournextmp.com">YourNextMP.com</a>,
 with many thanks.</p>
 
-<p>You can use the data from this site under the terms of the
-Creative Commons license
+<p>You can use the data from this site, via the
+<a href="{% url 'help-api' %}">API or CSV download</a>, under the
+terms of the Creative Commons license
 <a href="https://creativecommons.org/licenses/by-sa/4.0/">Attribution-ShareAlike
 (CC-BY-SA)</a> with the exception of:</p>
 

--- a/candidates/templates/candidates/about.html
+++ b/candidates/templates/candidates/about.html
@@ -42,7 +42,7 @@ terms of the Creative Commons license
 
 <ul>
 <li>The party logos, which are taken from the Electoral Commission's website</li>
-<li>and candidate photos. The candidate photos are either
+<li>and candidate photos. The candidate photos are typically either
 submitted by the candidates themselves, or from sources where it
 seems reasonable that we might use them on this site, such as
 the party's official page for that candidate.</li>

--- a/candidates/templates/candidates/about.html
+++ b/candidates/templates/candidates/about.html
@@ -48,13 +48,6 @@ seems reasonable that we might use them on this site, such as
 the party's official page for that candidate.</li>
 </ul>
 
-<p>By submitting data to this site, you agree that it may be
-distributed from this site
-under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>
-or (in case we decide to offer it under alternative licenses
-after <a href="https://github.com/mysociety/yournextmp-popit/issues/62">further
-discussion</a>) <a href="http://creativecommons.org/publicdomain/zero/1.0/">CC0</a>
-or <a href="http://opendatacommons.org/licenses/odbl/">ODbL</a>.
 
 <p>The privacy policy of this site can be found
 <a href="{% url 'help-privacy' %}">here</a>.</p>

--- a/candidates/templates/candidates/about.html
+++ b/candidates/templates/candidates/about.html
@@ -63,6 +63,8 @@ but please be warned that this snapshot will become inaccurate very quickly
 - please use
 <a href="{% url 'help-api' %}">the up-to-date data</a> instead.
 
+<h3>Privacy Policy</h3>
+
 <p>The privacy policy of this site can be found
 <a href="{% url 'help-privacy' %}">here</a>.</p>
 

--- a/candidates/templates/candidates/about.html
+++ b/candidates/templates/candidates/about.html
@@ -48,6 +48,10 @@ seems reasonable that we might use them on this site, such as
 the party's official page for that candidate.</li>
 </ul>
 
+<p>If the CC-BY-SA licence is problematic for you, but you feel that
+you have a worthwhile use of the data in mind,
+please <a href="mailto:yournextmp@mysociety.org">contact us</a> to
+discuss your situation further.</p>
 
 <p>The privacy policy of this site can be found
 <a href="{% url 'help-privacy' %}">here</a>.</p>

--- a/candidates/templates/candidates/about.html
+++ b/candidates/templates/candidates/about.html
@@ -53,6 +53,16 @@ you have a worthwhile use of the data in mind,
 please <a href="mailto:yournextmp@mysociety.org">contact us</a> to
 discuss your situation further.</p>
 
+<p>For complicated reasons relating to database licensing, we have put
+the data as of the 4th of March 2015 into the public domain by
+declaring it to
+be <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>. This
+data is available
+<a href="{{ MEDIA_URL }}csv-archives/cc0-snapshot-out-of-date/">here</a>
+but please be warned that this snapshot will become inaccurate very quickly
+- please use
+<a href="{% url 'help-api' %}">the up-to-date data</a> instead.
+
 <p>The privacy policy of this site can be found
 <a href="{% url 'help-privacy' %}">here</a>.</p>
 


### PR DESCRIPTION
Previously the agreement with our users was a paragraph
on the About page. Now we've introduced a click-through
agreement to do copyright assignment, we need to remove
this old and problematic wording. That's done in: e89f9d5

The other key change is to make a one-off snapshot CC0
release of the data up to this point; essentially we're putting
the data up to this point into the public domain, which we
said in the previous agreement we might do, and then
further contributions on top of that will be unambiguously
owned by Democracy Club. This includes a warning that
this snapshot will rapidly become out of date, and a
strong suggestion that users should use the up-to-date
data instead. That's done in 76aa714.

There are also various other small edits to improve the
clarify of this page.