### PR TITLE
Optionally disable submit buttons on first click

### DIFF
--- a/candidates/static/js/person_form.js
+++ b/candidates/static/js/person_form.js
@@ -98,8 +98,16 @@ function setUpStandingCheckbox() {
   });
 }
 
+function setUpOneClickSubmitButtons() {
+  $('[data-value-after-click]').on('click', function(){
+    var val = $(this).attr('data-value-after-click');
+    $(this).val(val).prop('disabled', true);
+  });
+}
+
 $(document).ready(function() {
   setUpPartySelect2s();
   setUpConstituencySelect2();
   setUpStandingCheckbox();
+  setUpOneClickSubmitButtons();
 });

--- a/candidates/templates/candidates/constituency.html
+++ b/candidates/templates/candidates/constituency.html
@@ -82,7 +82,7 @@
           </p>
         {% endfor %}
         <input type="hidden" id="id_constituency" name="constituency" value="{{ mapit_area_id }}">
-      <input type="submit" class="button" value="Add new candidate">
+      <input type="submit" class="button" value="Add new candidate" data-value-after-click="Adding new candidate…">
       <a class="hide-new-candidate-form button secondary">Cancel</a>
     </form>
 

--- a/candidates/templates/candidates/person-create.html
+++ b/candidates/templates/candidates/person-create.html
@@ -10,7 +10,7 @@
   <form id="person-details" action="{% url 'person-create' %}" method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <input type="submit" class="button" value="Save changes">
+    <input type="submit" class="button" value="Save changes" data-value-after-click="Saving changes…">
   </form>
 
 {% include 'candidates/person-versions.html' %}

--- a/candidates/templates/candidates/person-edit.html
+++ b/candidates/templates/candidates/person-edit.html
@@ -205,7 +205,7 @@
       </p>
     </div>
 
-    <input type="submit" class="button" value="Save changes">
+    <input type="submit" class="button" value="Save changes" data-value-after-click="Saving…">
   </form>
 
 </div>


### PR DESCRIPTION
Fixes #203.

Just add `data-value-after-click="some string"` to any form element (eg: an input or button) you want to disable after the first click.

![screen shot 2015-03-10 at 09 18 33](https://cloud.githubusercontent.com/assets/739624/6572108/5d4cbe06-c707-11e4-9d6d-a722b3571192.png)
