### PR TITLE
Strengthened language of assignment

### DIFF
--- a/candidates/templates/candidates/ask-for-copyright-assignment.html
+++ b/candidates/templates/candidates/ask-for-copyright-assignment.html
@@ -27,7 +27,7 @@
   {{ form.assigned_to_dc.errors }}
   {{ form.assigned_to_dc }}
     <label for="{{ form.assigned_to_dc.id_for_label }}">
-      <strong>Yes, I agree to assign the copyright of my contributions
+      <strong>I assign the copyright of my contributions
       to YourNextMP (apart from photo uploads) to Democracy Club
       Limited.</strong>
     </label>


### PR DESCRIPTION
It is possible to assign future copyright. Hence saying "I assign ..." will assign future copyright whereas "I agree to assign ..." may be interpreted as meaning that I agree to execute an assignment in the future. Until I actually do assign, there is no assignment of the legal rights in the copyright. Obscure and unlikely to be essential, but I would prefer it as a tweak.