### PR TITLE
change wording in person-view for PPC page link

### DIFF
--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -84,7 +84,7 @@
     <dd>{% if person.wikipedia_url %}<a rel="nofollow" href="{{ person.wikipedia_url }}">{{ person.wikipedia_url }}</a>{% endif %}</dd>
     <dt>LinkedIn page</dt>
     <dd>{% if person.linkedin_url %}<a rel="nofollow" href="{{ person.linkedin_url }}">{{ person.linkedin_url }}</a>{% endif %}</dd>
-    <dt>Official party page</dt>
+    <dt>Party PPC page</dt>
     <dd>{% if person.party_ppc_page_url %}<a rel="nofollow" href="{{ person.party_ppc_page_url }}">{{ person.party_ppc_page_url }}</a>{% endif %}</dd>
   </dl>
 


### PR DESCRIPTION
I've seen a significant number of cases of edits by candidates where they seem to think that "Official party page" means their party homepage and put in the URL of their party's main website.

I've updated the wording to bring it more in line with the person edit form, to say "Party PPC page", which I think is more obvious.