### PR TITLE
Add commands to clean up bogus data in the YourNextMP PopIt

### DIFF
--- a/candidates/management/commands/candidates_fix_image_metadata.py
+++ b/candidates/management/commands/candidates_fix_image_metadata.py
@@ -1,0 +1,97 @@
+from PIL import Image
+from hashlib import md5
+import re
+import requests
+import sys
+from StringIO import StringIO
+
+from candidates.popit import PopItApiMixin, popit_unwrap_pagination
+from candidates.update import fix_dates
+from moderation_queue.views import PILLOW_FORMAT_MIME_TYPES
+
+from django.core.management.base import BaseCommand
+
+from slumber.exceptions import HttpClientError
+
+def fix_image_mime_type(image):
+    mime_type = image.get('mime_type')
+    if mime_type:
+        return
+    try:
+        image_url = image['url']
+        r = requests.get(image_url)
+        pillow_image = Image.open(StringIO(r.content))
+    except IOError as e:
+        if 'cannot identify image file' in unicode(e):
+            print "Unknown image format in {0}".format(image_url)
+            return
+        raise
+    new_mime_type = PILLOW_FORMAT_MIME_TYPES[pillow_image.format]
+    image['mime_type'] = new_mime_type
+    print "    Setting mime_type to", new_mime_type
+
+def fix_image_metadata(image):
+    notes = image.get('notes', '')
+    # If the notes field has an MD5sum in it, then it was from the
+    # import PPC script, so move that to an md5sum field (as
+    # organization images have) and set the moderator_why_allowed to
+    # 'profile-photo'
+    m = re.search(r'^md5sum:([a-f0-9]+)', notes)
+    if m:
+        image['md5sum'] = m.group(1)
+        image['moderator_why_allowed'] = 'profile-photo'
+        image['notes'] = 'Scraped from the official party PPC page'
+        print "    Migrated old PPC scraped image"
+    # If there is a 'why_allowed' and 'justification_for_use' field,
+    # this was from before we switched to separating the user's and
+    # moderator's reason for allowing the photo, so migrate those
+    # fields.
+    if image.get('why_allowed') and image.get('justification_for_use'):
+        why_allowed = image.pop('why_allowed')
+        justification_for_use = image.pop('justification_for_use')
+        image['moderator_why_allowed'] = why_allowed
+        image['user_why_allowed'] = why_allowed
+        image['user_justification_for_use'] = justification_for_use
+        print "    Migrated from old why_allowed", why_allowed
+        print "    Migrated from old justification_for_use", justification_for_use
+
+def ensure_md5sum_present(image):
+    if image.get('md5sum'):
+        return
+    image_url = image['url']
+    # Otherwise get the file and calculate its MD5sum
+    r = requests.get(image_url)
+    md5sum = md5(r.content).hexdigest()
+    image['md5sum'] = md5sum
+    print "    Setting md5sum field to", md5sum
+
+def fix_image(image):
+    fix_image_mime_type(image)
+    fix_image_metadata(image)
+    ensure_md5sum_present(image)
+
+
+class Command(PopItApiMixin, BaseCommand):
+
+    def handle(self, **options):
+        for person in popit_unwrap_pagination(
+                self.api.persons,
+                per_page=100
+        ):
+            msg = "Person {0}persons/{1}"
+            print msg.format(self.get_base_url(), person['id'])
+            for image in person.get('images', []):
+                print "  Image with URL:", image['url']
+                fix_image(image)
+                image.pop('_id', None)
+                # Some images have an empty 'created' field, which
+                # causes an Elasticsearch indexing error, so remove
+                # that if it's the case:
+                if not image.get('created'):
+                    image.pop('created', None)
+            fix_dates(person)
+            try:
+                self.api.persons(person['id']).put(person)
+            except HttpClientError as e:
+                print "HttpClientError", e.content
+                sys.exit(1)

--- a/candidates/management/commands/candidates_remove_bogus_dates.py
+++ b/candidates/management/commands/candidates_remove_bogus_dates.py
@@ -1,0 +1,59 @@
+import sys
+
+from candidates.popit import PopItApiMixin, popit_unwrap_pagination
+from candidates.update import fix_dates
+
+from django.core.management.base import BaseCommand
+
+from slumber.exceptions import HttpClientError
+
+
+def strip_bogus_fields(data, bogus_field_keys):
+    for key in bogus_field_keys:
+        if key in data:
+            print "Stripping out", key
+            del data[key]
+
+
+class Command(PopItApiMixin, BaseCommand):
+
+    def handle(self, **options):
+        for person in popit_unwrap_pagination(
+                self.api.persons,
+                per_page=100
+        ):
+            msg = "Person {0}persons/{1}"
+            print msg.format(self.get_base_url(), person['id'])
+            strip_bogus_fields(
+                person,
+                [
+                    'founding_date',
+                    'dissolution_date',
+                    'start_date',
+                    'end_date'
+                ]
+            )
+            for image in person.get('images', []):
+                image.pop('_id', None)
+                # Some images have an empty 'created' field, which
+                # causes an Elasticsearch indexing error, so remove
+                # that if it's the case:
+                if not image.get('created'):
+                    image.pop('created', None)
+                strip_bogus_fields(
+                    image,
+                    [
+                        'birth_date',
+                        'death_date',
+                        'founding_date',
+                        'dissolution_date',
+                        'start_date',
+                        'end_date'
+                    ]
+                )
+            fix_dates(person)
+            try:
+                self.api.persons(person['id']).put(person)
+            except HttpClientError as e:
+                print "HttpClientError", e.content
+                sys.exit(1)

--- a/candidates/management/commands/candidates_remove_last_party_from_versions.py
+++ b/candidates/management/commands/candidates_remove_last_party_from_versions.py
@@ -1,0 +1,40 @@
+import sys
+
+from candidates.popit import PopItApiMixin, popit_unwrap_pagination
+from candidates.update import fix_dates
+
+from django.core.management.base import BaseCommand
+
+from slumber.exceptions import HttpClientError
+
+
+class Command(PopItApiMixin, BaseCommand):
+
+    def handle(self, **options):
+        for person in popit_unwrap_pagination(
+                self.api.persons,
+                per_page=100
+        ):
+            needs_update = False
+            for version in person.get('versions', []):
+                data = version['data']
+                if data.get('last_party'):
+                    needs_update = True
+                    msg = "Fixing person {0}persons/{1}"
+                    print msg.format(self.get_base_url(), person['id'])
+                    del data['last_party']
+            if not needs_update:
+                continue
+            for image in person.get('images', []):
+                image.pop('_id', None)
+                # Some images have an empty 'created' field, which
+                # causes an Elasticsearch indexing error, so remove
+                # that if it's the case:
+                if not image.get('created'):
+                    image.pop('created', None)
+            fix_dates(person)
+            try:
+                self.api.persons(person['id']).put(person)
+            except HttpClientError as e:
+                print "HttpClientError", e.content
+                sys.exit(1)

--- a/candidates/update.py
+++ b/candidates/update.py
@@ -235,8 +235,9 @@ class PersonParseMixin(PopItApiMixin):
 # dates to an empty string, which will stop the PopIt record
 # being indexed by Elasticsearch.
 def fix_dates(data):
-    if not data['birth_date']:
-        data['birth_date'] = None
+    for key in ('birth_date', 'death_date'):
+        if key in data and not data[key]:
+            data[key] = None
     for other_name in data.get('other_names', []):
         for key in ('start_date', 'end_date'):
             if key in other_name and not other_name[key]:

--- a/conf/packages
+++ b/conf/packages
@@ -6,3 +6,5 @@ opencv-data
 python-opencv
 libxml2-dev
 libxslt-dev
+libffi-dev
+libssl-dev

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -193,6 +193,7 @@ class PhotoReviewTests(WebTest):
              'user_why_allowed': u'public-domain',
              'moderator_why_allowed': u'profile-photo',
              'uploaded_by_user': u'john',
+             'md5sum': '603b269fccc667d72dbf462de31476b0',
              'mime_type': 'image/jpeg'}
         )
         las = LoggedAction.objects.all()

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -17,6 +17,7 @@ from PIL import Image
 
 from braces.views import StaffuserRequiredMixin
 
+from candidates.management.images import get_file_md5sum
 from candidates.update import PersonParseMixin, PersonUpdateMixin
 
 from .forms import UploadPersonPhotoForm, PhotoReviewForm
@@ -171,6 +172,7 @@ class PhotoReview(StaffuserRequiredMixin, PersonParseMixin, PersonUpdateMixin, T
             person_id=self.queued_image.popit_person_id
         )
         data = {
+            'md5sum': get_file_md5sum(ntf.name),
             'user_why_allowed': self.queued_image.why_allowed,
             'user_justification_for_use': self.queued_image.justification_for_use,
             'moderator_why_allowed': moderator_why_allowed,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ WebOb==1.4
 WebTest==2.0.15
 argparse==1.2.1
 beautifulsoup4==4.3.2
+cffi==0.9.2
 coverage==3.7.1
+cryptography==0.8
 django-allauth==0.18.0
 django-braces==1.4.0
 django-debug-toolbar==1.2.1
@@ -16,6 +18,7 @@ django-nose==1.3
 django-pipeline==1.3.25
 django-webtest==1.7.7
 docutils==0.10
+enum34==1.0.4
 futures==2.1.6
 ipdb==0.8
 ipython==2.1.0
@@ -23,14 +26,18 @@ jsonpatch==1.9
 jsonpointer==1.6
 lxml==3.4.1
 mock==1.0.1
+ndg-httpsclient==0.3.3
 nose==1.3.4
 numpy==1.9.1
 oauthlib==0.6.3
 psycopg2==2.5.4
+pyOpenSSL==0.14
+pyasn1==0.1.7
+pycparser==2.10
 python-dateutil==2.2
 python-openid==2.2.5
 python-slugify==0.0.7
-requests==2.4.1
+requests==2.5.3
 requests-oauthlib==0.4.1
 six==1.7.3
 slumber==0.6.0


### PR DESCRIPTION
Bugs at various stages have introduced some extra fields, and the image
metadata has been through various changes; these commands are one-off
scripts that should clean these up.