### PR TITLE
Some small improvements to the photo review page

### DIFF
--- a/candidates/update.py
+++ b/candidates/update.py
@@ -228,6 +228,7 @@ class PersonParseMixin(PopItApiMixin):
         else:
             extra_for_template['date_of_birth'] = extra_for_template['age'] = ''
         extra_for_template['last_party'] = self.get_last_party(person.popit_data)
+        extra_for_template['images'] = person.popit_data.get('images', [])
         return result, extra_for_template
 
 

--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -9,11 +9,13 @@ class QueuedImage(models.Model):
     APPROVED = 'approved'
     REJECTED = 'rejected'
     UNDECIDED = 'undecided'
+    IGNORE = 'ignore'
 
     DECISION_CHOICES = (
         (APPROVED, 'Approved'),
         (REJECTED, 'Rejected'),
         (UNDECIDED, 'Undecided'),
+        (IGNORE, 'Ignore'),
     )
 
     PUBLIC_DOMAIN = 'public-domain'

--- a/moderation_queue/static/moderation_queue/css/crop.css
+++ b/moderation_queue/static/moderation_queue/css/crop.css
@@ -1,5 +1,0 @@
-.image-for-review-container img {
-  max-width: none;
-  max-height: none;
-  height: auto;
-  width: auto; }

--- a/moderation_queue/static/moderation_queue/css/crop.scss
+++ b/moderation_queue/static/moderation_queue/css/crop.scss
@@ -1,3 +1,6 @@
+@import "../../../../candidates/static/foundation/scss/normalize";
+@import "../../../../candidates/static/foundation/scss/foundation";
+
 /* This removes all size-related styles from the image for review; if
    we don't do this then Jcrop gets confused about the true size of
    the image and returns the wrong coordinates. */
@@ -7,4 +10,22 @@
   max-height: none;
   height: auto;
   width: auto;
+}
+
+@media #{$large-up} {
+  .photo-review__primary {
+    @include grid-column($columns: 9, $collapse: true);
+  }
+
+  .photo-review__secondary {
+    @include grid-column($columns: 2, $offset: 1, $collapse: true);
+
+    & + * {
+      clear: both;
+    }
+  }
+}
+
+.photo-review__existing-image {
+  margin: 0.3em;
 }

--- a/moderation_queue/static/moderation_queue/js/crop.js
+++ b/moderation_queue/static/moderation_queue/js/crop.js
@@ -46,7 +46,8 @@ jQuery(function($) {
     onSelect: adjustFormValues,
     onChange: adjustFormValues,
     boxWidth: 600,
-    boxHeight: 600
+    boxHeight: 600,
+    aspectRatio: 1
   });
 
 });

--- a/moderation_queue/static/moderation_queue/js/crop.js
+++ b/moderation_queue/static/moderation_queue/js/crop.js
@@ -19,6 +19,12 @@ jQuery(function($) {
       $('.justification_for_use').show();
       $('.moderator-reason').hide();
       $('#decision-submit').hide();
+    } else if (value == 'ignore') {
+      $('.rejection_reason').hide();
+      $('.justification_for_use').hide();
+      $('.moderator-reason').hide();
+      $('#decision-submit').val('Ignore');
+      $('#decision-submit').show();
     }
   }
 

--- a/moderation_queue/templates/moderation_queue/photo-review.html
+++ b/moderation_queue/templates/moderation_queue/photo-review.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% load compressed %}
+{% load imagefixes %}
 
 {% block extra_css %}
 {% compressed_css 'image-review' %}
@@ -20,119 +21,139 @@
 
 {% block content %}
 
-<p>{{ form.errors }}</p>
+<div class="photo-review__primary">
 
-<p>Please check that this is really
-<a href="{% url 'person-view' person.id person.name|slugify %}">{{ person.name }}</a>
-({{ person_extra.last_party.name }}) before
-approving the upload. This
-<a href="{{ google_image_search_url }}">Google
-Image search</a> may be a good start.</p>
+  <p>{{ form.errors }}</p>
 
-<h3>Click and drag in the image to crop</h3>
+  <p>Please check that this is really
+  <a href="{% url 'person-view' person.id person.name|slugify %}">{{ person.name }}</a>
+  ({{ person_extra.last_party.name }}) before
+  approving the upload. This
+  <a href="{{ google_image_search_url }}">Google
+  Image search</a> may be a good start.</p>
 
-<div class="image-for-review-container">
-  <img id="image-for-review" src="{{ queued_image.image.url }}">
-</div>
+  <h3>Click and drag in the image to crop</h3>
 
-<form id="photo-review-form" method="post">
-
-  {% csrf_token %}
-  {{ form.non_field_errors }}
-
-  <p>
-      {{ form.queued_image_id }}
-  </p>
-
-  <div class="crop-coordinates">
-    <p>
-      {{ form.x_min.errors }}
-      <label for="{{ form.x_min.id_for_label }}">Minimum X co-ordinate:</label>
-      {{ form.x_min }}
-    </p>
-    <p>
-      {{ form.x_max.errors }}
-      <label for="{{ form.x_max.id_for_label }}">Maximum X co-ordinate:</label>
-      {{ form.x_max }}
-    </p>
-    <p>
-      {{ form.y_min.errors }}
-      <label for="{{ form.y_min.id_for_label }}">Minimum Y co-ordinate:</label>
-      {{ form.y_min }}
-    </p>
-    <p>
-      {{ form.y_max.errors }}
-      <label for="{{ form.y_max.id_for_label }}">Maximum Y co-ordinate:</label>
-      {{ form.y_max }}
-    </p>
+  <div class="image-for-review-container">
+    <img id="image-for-review" src="{{ queued_image.image.url }}">
   </div>
 
-  <h3>User-submitted information</h3>
+  <form id="photo-review-form" method="post">
 
-  {% with username=queued_image.user.username %}
+    {% csrf_token %}
+    {{ form.non_field_errors }}
 
-    <p>Uploaded by username with confirmed email
-      <tt>{{ queued_image.user.email }}</tt>.
-      {% if person.email %}
-        (The candidate's unconfirmed email address is
-        <tt>{{ person.email }}</tt>.)
+    <p>
+        {{ form.queued_image_id }}
+    </p>
+
+    <div class="crop-coordinates">
+      <p>
+        {{ form.x_min.errors }}
+        <label for="{{ form.x_min.id_for_label }}">Minimum X co-ordinate:</label>
+        {{ form.x_min }}
+      </p>
+      <p>
+        {{ form.x_max.errors }}
+        <label for="{{ form.x_max.id_for_label }}">Maximum X co-ordinate:</label>
+        {{ form.x_max }}
+      </p>
+      <p>
+        {{ form.y_min.errors }}
+        <label for="{{ form.y_min.id_for_label }}">Minimum Y co-ordinate:</label>
+        {{ form.y_min }}
+      </p>
+      <p>
+        {{ form.y_max.errors }}
+        <label for="{{ form.y_max.id_for_label }}">Maximum Y co-ordinate:</label>
+        {{ form.y_max }}
+      </p>
+    </div>
+
+    <h3>User-submitted information</h3>
+
+    {% with username=queued_image.user.username %}
+
+      <p>Uploaded by username with confirmed email
+        <tt>{{ queued_image.user.email }}</tt>.
+        {% if person.email %}
+          (The candidate's unconfirmed email address is
+          <tt>{{ person.email }}</tt>.)
+        {% endif %}
+        </p>
+
+      {% if why_allowed == 'public-domain' %}
+        <p>
+          {{ username }} asserted that photo is free of copyright restrictions
+        </p>
+      {% elif why_allowed == 'copyright-assigned' %}
+        <p>
+          {{ username }} assigned the copyright to Democracy Club
+        </p>
+      {% elif why_allowed == 'profile-photo' %}
+        <p>
+          {{ username }} said that this is the candidate's public profile
+          photo from social media or their official campaign page
+        </p>
       {% endif %}
+
+      {% if justification_for_use %}
+        <p>
+          {{ username }}'s justification for use of this photo was:
+          &#8220;{{ justification_for_use }}&#8221;
+        </p>
+      {% endif %}
+
+    {% endwith %}
+
+    <h3>Your decision</h3>
+
+    <div id="moderator-photo-decision">
+      <p>
+          {{ form.decision.errors }}
+          <label for="{{ form.decision.id_for_label }}">Decision:</label>
+          {{ form.decision }}
       </p>
 
-    {% if why_allowed == 'public-domain' %}
-      <p>
-        {{ username }} asserted that photo is free of copyright restrictions
+      <p class="moderator-reason">
+          {{ form.moderator_why_allowed.errors }}
+          <label for="{{ moderator_why_allowed.id_for_label }}">Why <em>you</em> think it's allowed:</label>
+          {{ form.moderator_why_allowed }}
       </p>
-    {% elif why_allowed == 'copyright-assigned' %}
-      <p>
-        {{ username }} assigned the copyright to Democracy Club
-      </p>
-    {% elif why_allowed == 'profile-photo' %}
-      <p>
-        {{ username }} said that this is the candidate's public profile
-        photo from social media or their official campaign page
-      </p>
-    {% endif %}
 
-    {% if justification_for_use %}
-      <p>
-        {{ username }}'s justification for use of this photo was:
-        &#8220;{{ justification_for_use }}&#8221;
+      <p class="rejection_reason">
+          {{ form.rejection_reason.errors }}
+          <label for="{{ form.rejection_reason.id_for_label }}">Reason
+            for rejection (<strong>Warning:</strong> this will be emailed to
+            the user):
+          </label>
+          {{ form.rejection_reason }}
       </p>
+
+      <input type="submit" id="decision-submit" class="button" value="Submit">
+
+      <a href="{% url 'photo-review-list' %}" class="button">Cancel</a>
+    </div>
+  </form>
+</div>
+
+<div class="photo-review__secondary">
+
+  <h4>Existing candidate images</h4>
+
+  {% with images=person_extra.images %}
+
+    {% if images %}
+      {% for image in images %}
+        <img class="photo-review__existing-image" src="{{ image.proxy_url|fixproxyurl }}/0/200"
+          alt="{{ image.notes }}" title="{{ image.notes }}">
+      {% endfor %}
+    {% else %}
+      <p>There were no existing images for this candidate.</p>
     {% endif %}
 
   {% endwith %}
 
-  <h3>Your decision</h3>
-
-  <div id="moderator-photo-decision">
-    <p>
-        {{ form.decision.errors }}
-        <label for="{{ form.decision.id_for_label }}">Decision:</label>
-        {{ form.decision }}
-    </p>
-
-    <p class="moderator-reason">
-        {{ form.moderator_why_allowed.errors }}
-        <label for="{{ moderator_why_allowed.id_for_label }}">Why <em>you</em> think it's allowed:</label>
-        {{ form.moderator_why_allowed }}
-    </p>
-
-    <p class="rejection_reason">
-        {{ form.rejection_reason.errors }}
-        <label for="{{ form.rejection_reason.id_for_label }}">Reason
-          for rejection (<strong>Warning:</strong> this will be emailed to
-          the user):
-        </label>
-        {{ form.rejection_reason }}
-    </p>
-
-    <input type="submit" id="decision-submit" class="button" value="Submit">
-
-    <a href="{% url 'photo-review-list' %}" class="button">Cancel</a>
-  <div>
-
-
-</form>
+</div>
 
 {% endblock %}

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -203,6 +203,8 @@ class PhotoReviewTests(WebTest):
         self.assertEqual(la.action_type, 'photo-approve')
         self.assertEqual(la.popit_person_id, '2009')
 
+        self.assertEqual(QueuedImage.objects.get(pk=self.q1.id).decision, 'approved')
+
     @patch('moderation_queue.views.send_mail')
     @patch('moderation_queue.views.requests.post')
     @patch('candidates.popit.PopIt')
@@ -249,6 +251,8 @@ class PhotoReviewTests(WebTest):
 
         self.assertEqual(mock_requests_post.call_count, 0)
 
+        self.assertEqual(QueuedImage.objects.get(pk=self.q1.id).decision, 'rejected')
+
     @patch('moderation_queue.views.send_mail')
     @patch('moderation_queue.views.requests.post')
     @patch('candidates.popit.PopIt')
@@ -279,3 +283,5 @@ class PhotoReviewTests(WebTest):
 
         self.assertEqual(mock_send_mail.call_count, 0)
         self.assertEqual(mock_requests_post.call_count, 0)
+
+        self.assertEqual(QueuedImage.objects.get(pk=self.q1.id).decision, 'undecided')

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -268,6 +268,9 @@ class PhotoReview(StaffuserRequiredMixin, PersonParseMixin, PersonUpdateMixin, T
             # If it's left as undecided, just redirect back to the
             # photo review queue...
             pass
+        elif decision == 'ignore':
+            self.queued_image.decision = 'ignore'
+            self.queued_image.save()
         else:
             raise Exception("BUG: unexpected decision {0}".format(decision))
         return HttpResponseRedirect(reverse('photo-review-list'))


### PR DESCRIPTION
This pull request:

* Shows the already uploaded images of the candidate on the photo review page
* Adds an "ignore" option when reviewing photos (e.g. when someone has uploaded a duplicate)

![existing-candidate-images](https://cloud.githubusercontent.com/assets/7907/6707911/7d65c05e-cd63-11e4-957c-5d250d4406e0.png)

![existing-candidate-images-responsive](https://cloud.githubusercontent.com/assets/7907/6707912/81e3a97a-cd63-11e4-86b2-aa5deb29e0ce.png)

<!---
@huboard:{"order":258.5}
-->
