### PR TITLE
Hardcode TUSC image to use

### DIFF
--- a/candidates/management/commands/candidates_update_popit_parties_from_ec_data.py
+++ b/candidates/management/commands/candidates_update_popit_parties_from_ec_data.py
@@ -38,6 +38,8 @@ IMAGES_TO_USE = {
     'party:77': 'Emblem 3',
     # Ulster Unionist Party
     'party:83': 'Emblem 2',
+    # Trade Unionist and Socialist Coalition
+    'party:804': 'Emblem 3',
 }
 
 def sort_emblems(emblems, party_id):


### PR DESCRIPTION
Andy wrote:

> Regarding the party logo, we currently use the primary graphic held by the Electoral Commission. The logo you sent is on file with the Electoral Commission, so I have contacted our developers to see if it’s a possibility to use that one instead. It’s likely it will be necessary to use the same graphic for all party members – is that okay?

TUSC candidate wrote:

> Yes, I think that would be good. This is the one that is being used by a majority of the candidates. 

Refs #265.