### PR TITLE
Finer-grained permissions for merging candidates and reviewing photos

### DIFF
--- a/auth_helpers/migrations.py
+++ b/auth_helpers/migrations.py
@@ -1,0 +1,38 @@
+from django.contrib.auth.management import create_permissions
+
+
+def get_migration_group_create(group_name, permission_codenames):
+
+    def add_group_and_permissions(apps, schema_editor, create_if_missing=True):
+        Permission = apps.get_model('auth', 'Permission')
+        Group = apps.get_model('auth', 'Group')
+        try:
+            permissions = Permission.objects.filter(
+                codename__in=permission_codenames
+            )
+        except Permission.DoesNotExist:
+            if create_if_missing:
+                # This is a way of making sure the permissions exist taken from:
+                # https://code.djangoproject.com/ticket/23422#comment:6
+                assert not getattr(apps, 'models_module', None)
+                apps.models_module = True
+                create_permissions(apps, verbosity=0)
+                apps.models_module = None
+                return add_group_and_permissions(
+                    apps, schema_editor, create_if_missing=False
+                )
+            else:
+                raise
+        new_group = Group.objects.create(name=group_name)
+        for permission in permissions:
+            new_group.permissions.add(permission)
+
+    return add_group_and_permissions
+
+def get_migration_group_delete(group_name):
+
+    def remove_group(apps, schema_editor):
+        Group = apps.get_model('auth', 'Group')
+        Group.objects.get(name=group_name).delete()
+
+    return remove_group

--- a/auth_helpers/templates/auth_helpers/group_permission_denied.html
+++ b/auth_helpers/templates/auth_helpers/group_permission_denied.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block body_class %}{% endblock %}
+
+{% block title %}Permission denied{% endblock %}
+
+{% block hero %}
+  <h1>Permission denied</h1>
+{% endblock %}
+
+{% block content %}
+<p>
+You must be in the member of a particular group in order to view that page.
+Please contact the administrators of the site if you feel that you should
+have access to this page.
+</p>
+
+{% endblock %}

--- a/auth_helpers/views.py
+++ b/auth_helpers/views.py
@@ -1,0 +1,29 @@
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import Group
+from django.shortcuts import render
+from django.utils.decorators import method_decorator
+
+
+def user_in_group(user, group_name):
+    if not user.is_authenticated():
+        return False
+    group = Group.objects.get(name=group_name)
+    return group in user.groups.all()
+
+
+class GroupRequiredMixin(object):
+
+    """A mixin that requires the user is a member of a particular group
+
+    You should set 'required_group_name' on the class that uses this
+    mixin to the name of the group that the user must be a member of."""
+
+    permission_denied_template = 'auth_helpers/group_permission_denied.html'
+
+    @method_decorator(login_required)
+    def dispatch(self, request, *args, **kwargs):
+        if not user_in_group(request.user, self.required_group_name):
+            return render(request, self.permission_denied_template, status=403)
+        return super(GroupRequiredMixin, self).dispatch(
+            request, *args, **kwargs
+        )

--- a/candidates/migrations/0004_add_trusted_to_merge_group.py
+++ b/candidates/migrations/0004_add_trusted_to_merge_group.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from auth_helpers.migrations import (
+    get_migration_group_create,
+    get_migration_group_delete,
+)
+from candidates.models import TRUSTED_TO_MERGE_GROUP_NAME
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0003_create_user_terms_agreements'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            get_migration_group_create(TRUSTED_TO_MERGE_GROUP_NAME, []),
+            get_migration_group_delete(TRUSTED_TO_MERGE_GROUP_NAME),
+        )
+    ]

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -16,6 +16,8 @@ from slumber.exceptions import HttpServerError
 
 from .static_data import MapItData
 
+TRUSTED_TO_MERGE_GROUP_NAME = 'Trusted To Merge'
+
 form_simple_fields = (
     'honorific_prefix', 'name', 'honorific_suffix', 'email', 'birth_date',
     'gender'

--- a/candidates/templates/candidates/person-edit.html
+++ b/candidates/templates/candidates/person-edit.html
@@ -225,7 +225,7 @@
        {{ person.name }}</a>.</p>
   </div>
 
-  {% if user.is_superuser %}
+  {% if user_can_merge %}
     <form class="person__actions__action person__actions__merge" id="person-merge" action="{% url 'person-merge' person_id=person.id %}" method="post">
       {% csrf_token %}
       <h2>Is this a duplicate person?</h2>

--- a/moderation_queue/migrations/0008_add_photo_review_permissions.py
+++ b/moderation_queue/migrations/0008_add_photo_review_permissions.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from auth_helpers.migrations import (
+    get_migration_group_create,
+    get_migration_group_delete,
+)
+from moderation_queue.models import PHOTO_REVIEWERS_GROUP_NAME
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('moderation_queue', '0007_auto_20150303_1420'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            get_migration_group_create(
+                PHOTO_REVIEWERS_GROUP_NAME, ['change_queuedimage']
+            ),
+            get_migration_group_delete(
+                PHOTO_REVIEWERS_GROUP_NAME
+            )
+        )
+    ]

--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -4,6 +4,9 @@ from django.contrib.auth.models import User
 from django.db import models
 
 
+PHOTO_REVIEWERS_GROUP_NAME = 'Photo Reviewers'
+
+
 class QueuedImage(models.Model):
 
     APPROVED = 'approved'

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -15,13 +15,12 @@ from django.views.generic import ListView, TemplateView
 
 from PIL import Image
 
-from braces.views import StaffuserRequiredMixin
-
+from auth_helpers.views import GroupRequiredMixin
 from candidates.management.images import get_file_md5sum
 from candidates.update import PersonParseMixin, PersonUpdateMixin
 
 from .forms import UploadPersonPhotoForm, PhotoReviewForm
-from .models import QueuedImage
+from .models import QueuedImage, PHOTO_REVIEWERS_GROUP_NAME
 
 from candidates.popit import create_popit_api_object
 from candidates.models import PopItPerson, LoggedAction
@@ -76,8 +75,9 @@ class PhotoUploadSuccess(PersonParseMixin, TemplateView):
         return context
 
 
-class PhotoReviewList(StaffuserRequiredMixin, ListView):
+class PhotoReviewList(GroupRequiredMixin, ListView):
     template_name = 'moderation_queue/photo-review-list.html'
+    required_group_name = PHOTO_REVIEWERS_GROUP_NAME
 
     def get_queryset(self):
         return QueuedImage.objects. \
@@ -99,11 +99,12 @@ def tidy_party_name(name):
     return name
 
 
-class PhotoReview(StaffuserRequiredMixin, PersonParseMixin, PersonUpdateMixin, TemplateView):
+class PhotoReview(GroupRequiredMixin, PersonParseMixin, PersonUpdateMixin, TemplateView):
     """The class-based view for approving or rejecting a particular photo"""
 
     template_name = 'moderation_queue/photo-review.html'
     http_method_names = ['get', 'post']
+    required_group_name = PHOTO_REVIEWERS_GROUP_NAME
 
     def get_google_image_search_url(self, person, person_extra):
         image_search_query = '"{name}" "{party}"'.format(

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -93,6 +93,7 @@ INSTALLED_APPS = (
     'tasks',
     'cached_counts',
     'moderation_queue',
+    'auth_helpers',
     'debug_toolbar',
 )
 


### PR DESCRIPTION
Previously, the only way we could give additional permissions to users on the
site was to make them staff or a superuser; these both need you to put a lot
of trust in the users, since they confer other abilities (e.g. to see other users'
email addresses).

This commit introduces two groups called 'Photo Reviewers' and 'Trusted To
Merge' which we can selectively add users to if we trust them to help out with
those tasks.