### PR TITLE
Add notification of number photos for review

### DIFF
--- a/candidates/static/candidates/_header.scss
+++ b/candidates/static/candidates/_header.scss
@@ -21,6 +21,13 @@
   }
 }
 
+.header__nav__notification {
+  background-color: red;
+  color: black;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
+
 .header__nav {
   padding-top: 1em;
   padding-bottom: 1em;

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -282,10 +282,6 @@ class UpdatePersonView(LoginRequiredMixin, CandidacyMixin, PersonParseMixin, Per
         )
 
         context['versions'] = get_version_diffs(context['person']['versions'])
-        context['user_can_merge'] = user_in_group(
-            self.request.user,
-            TRUSTED_TO_MERGE_GROUP_NAME
-        )
 
         return context
 

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -2,7 +2,7 @@ from datetime import date
 from django.conf import settings
 from auth_helpers.views import user_in_group
 from candidates.models import election_date_2015, TRUSTED_TO_MERGE_GROUP_NAME
-from moderation_queue.models import PHOTO_REVIEWERS_GROUP_NAME
+from moderation_queue.models import QueuedImage, PHOTO_REVIEWERS_GROUP_NAME
 
 SETTINGS_TO_ADD = (
     'GOOGLE_ANALYTICS_ACCOUNT',
@@ -28,6 +28,16 @@ def election_date(request):
         'DATE_ELECTION': election_date_2015,
         'DATE_TODAY': date.today(),
     }
+
+
+def add_notification_data(request):
+    """Make the number of photos for review available in the template"""
+
+    result = {}
+    if request.user.is_authenticated():
+        result['photos_for_review'] = \
+            QueuedImage.objects.filter(decision='undecided').count()
+    return result
 
 
 def add_group_permissions(request):

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -1,6 +1,8 @@
 from datetime import date
 from django.conf import settings
-from candidates.models import election_date_2015
+from auth_helpers.views import user_in_group
+from candidates.models import election_date_2015, TRUSTED_TO_MERGE_GROUP_NAME
+from moderation_queue.models import PHOTO_REVIEWERS_GROUP_NAME
 
 SETTINGS_TO_ADD = (
     'GOOGLE_ANALYTICS_ACCOUNT',
@@ -25,4 +27,16 @@ def election_date(request):
     return {
         'DATE_ELECTION': election_date_2015,
         'DATE_TODAY': date.today(),
+    }
+
+
+def add_group_permissions(request):
+    """Add user_can_merge and user_can_review_photos"""
+
+    return {
+        context_variable: user_in_group(request.user, group_name)
+        for context_variable, group_name in (
+            ('user_can_merge', TRUSTED_TO_MERGE_GROUP_NAME),
+            ('user_can_review_photos', PHOTO_REVIEWERS_GROUP_NAME),
+        )
     }

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -69,6 +69,7 @@ TEMPLATE_CONTEXT_PROCESSORS += (
     "mysite.context_processors.add_settings",
     "mysite.context_processors.election_date",
     "mysite.context_processors.add_group_permissions",
+    "mysite.context_processors.add_notification_data",
 )
 
 # Application definition

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -68,6 +68,7 @@ TEMPLATE_CONTEXT_PROCESSORS += (
     "allauth.socialaccount.context_processors.socialaccount",
     "mysite.context_processors.add_settings",
     "mysite.context_processors.election_date",
+    "mysite.context_processors.add_group_permissions",
 )
 
 # Application definition

--- a/mysite/templates/base.html
+++ b/mysite/templates/base.html
@@ -53,6 +53,9 @@
         <a href="{% url 'help-about' %}" class="header__nav__logo">About</a>
         <a href="{% url 'constituencies' %}" class="header__nav__logo">Constituencies</a>
         <a href="{% url 'reports_home' %}" class="header__nav__logo">Numbers</a>
+        {% if user_can_review_photos and photos_for_review > 0 %}
+          <a href="{% url 'photo-review-list' %}" class="header__nav__logo header__nav__notification">{{ photos_for_review }}</a>
+        {% endif %}
         {% if user.is_authenticated %}
           <span class="header__nav__logout">
             Signed in as <strong>{{ user.username }}</strong>


### PR DESCRIPTION
Like this:

![photo-review-queue-notification](https://cloud.githubusercontent.com/assets/7907/6866093/6c63f748-d46c-11e4-94ed-e7f95329b424.png)

As well as a reminder for how many photos there are still
for review, this provides a link to the review queue on every
page for users who are able to do something about that.