### PR TITLE
Add a "make this the primary image" option when reviewing a photo

### DIFF
--- a/moderation_queue/forms.py
+++ b/moderation_queue/forms.py
@@ -52,6 +52,7 @@ class PhotoReviewForm(forms.Form):
     y_min = forms.IntegerField(min_value=0)
     y_max = forms.IntegerField(min_value=1)
     decision = forms.ChoiceField(choices=QueuedImage.DECISION_CHOICES)
+    make_primary = forms.BooleanField(required=False)
     rejection_reason = forms.CharField(
         widget=forms.Textarea(),
         required=False

--- a/moderation_queue/static/moderation_queue/js/crop.js
+++ b/moderation_queue/static/moderation_queue/js/crop.js
@@ -6,23 +6,27 @@ jQuery(function($) {
       $('.rejection_reason').show();
       $('.justification_for_use').hide();
       $('.moderator-reason').hide();
+      $('.make-primary').hide();
       $('#decision-submit').val('Reject');
       $('#decision-submit').show();
     } else if (value == 'approved') {
       $('.rejection_reason').hide();
       $('.justification_for_use').show();
       $('.moderator-reason').show();
+      $('.make-primary').show();
       $('#decision-submit').val('Approve');
       $('#decision-submit').show();
     } else if (value == 'undecided') {
       $('.rejection_reason').hide();
       $('.justification_for_use').show();
       $('.moderator-reason').hide();
+      $('.make-primary').hide();
       $('#decision-submit').hide();
     } else if (value == 'ignore') {
       $('.rejection_reason').hide();
       $('.justification_for_use').hide();
       $('.moderator-reason').hide();
+      $('.make-primary').hide();
       $('#decision-submit').val('Ignore');
       $('#decision-submit').show();
     }

--- a/moderation_queue/templates/moderation_queue/photo-review.html
+++ b/moderation_queue/templates/moderation_queue/photo-review.html
@@ -115,6 +115,12 @@
           {{ form.decision }}
       </p>
 
+      <p class="make-primary">
+        {{ form.make_primary }}
+        <label for="{{ form.make_primary.id_for_label }}">Make this the
+          primary image of the candidate?</label>
+      </p>
+
       <p class="moderator-reason">
           {{ form.moderator_why_allowed.errors }}
           <label for="{{ moderator_why_allowed.id_for_label }}">Why <em>you</em> think it's allowed:</label>

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -195,6 +195,7 @@ class PhotoReviewTests(WebTest):
              'user_why_allowed': u'public-domain',
              'moderator_why_allowed': u'profile-photo',
              'uploaded_by_user': u'john',
+             'index': 'first',
              'md5sum': '603b269fccc667d72dbf462de31476b0',
              'mime_type': 'image/png'}
         )


### PR DESCRIPTION
Sometimes it's clear that the uploaded image is a better one to
use for the candidate, while sometimes it's just an extra one that
it might be nice to have.  Previously, all approved photos were
appended to the images array, which meant they wouldn't be used.
This commit changes that, so that now there's a "make this the
primary image" option, which, when selected, will insert that image
at the front of the images array.

Fixes  #250