### PR TITLE
Add Cache-Control headers with max-age 20 of minutes

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -107,6 +107,7 @@ INSTALLED_APPS = (
 SITE_ID = 1
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.cache.UpdateCacheMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'candidates.middleware.PopItDownMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -116,6 +117,7 @@ MIDDLEWARE_CLASSES = (
     'candidates.middleware.CopyrightAssignmentMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (
@@ -300,3 +302,14 @@ FORCE_HTTPS_IMAGES = conf.get('FORCE_HTTPS_IMAGES')
 if conf.get('NGINX_SSL'):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
+if DEBUG:
+    CACHE_MIDDLEWARE_SECONDS = 0
+else:
+    CACHE_MIDDLEWARE_SECONDS = 60 * 20 # Twenty minutes


### PR DESCRIPTION
The Django cache middleware also adds a Vary: Cookie header to
responses, so this should mean that Varnish can serve cached
versions of these pages for 20 minutes to client that aren't
sending cookies.