### PR TITLE
Don't set the csrftoken cookie from the front page

### DIFF
--- a/candidates/templates/candidates/finder.html
+++ b/candidates/templates/candidates/finder.html
@@ -35,14 +35,12 @@ it’s a waste of money.</p>
 <div class="finder__forms">
 
   <form id="form-postcode" action="{% url 'lookup-postcode' %}" method="post" {% if show_name_form %}style="display: none"{% endif %}>
-    {% csrf_token %}
     {{ postcode_form.as_p }}
     <input type="submit" class="button" value="Show candidates" />
     <a class="show-other-form" href="{% url 'lookup-name' %}">Or select a constituency</a>
   </form>
 
   <form id="form-name" action="{% url 'lookup-name' %}" method="post" {% if show_postcode_form %}style="display: none"{% endif %}>
-    {% csrf_token %}
     {{ constituency_form.as_p }}
     <input type="submit" class="button" value="Show candidates" />
     <a class="show-other-form" href="{% url 'lookup-postcode' %}">Or search by postcode</a>

--- a/candidates/tests/test_finders.py
+++ b/candidates/tests/test_finders.py
@@ -99,14 +99,10 @@ class TestConstituencyNameFinderView(WebTest):
         self.assertIn('You must select a constituency', response)
 
     def test_post_invalid_constituency_id(self):
-        response = self.app.get('/')
-        form = response.forms['form-name']
-        csrftoken = form['csrfmiddlewaretoken'].value
         response = self.app.post(
             '/lookup/name',
             {
                 'constituency': 'made-up-555',
-                'csrfmiddlewaretoken': csrftoken,
             }
         )
         self.assertIn(

--- a/candidates/views/frontpage.py
+++ b/candidates/views/frontpage.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import FormView
 
 from .mixins import ContributorsMixin
@@ -10,6 +12,10 @@ from ..mapit import get_wmc_from_postcode
 class ConstituencyPostcodeFinderView(ContributorsMixin, FormView):
     template_name = 'candidates/finder.html'
     form_class = PostcodeForm
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(ConstituencyPostcodeFinderView, self).dispatch(*args, **kwargs)
 
     def form_valid(self, form):
         wmc = get_wmc_from_postcode(form.cleaned_data['postcode'])
@@ -29,6 +35,10 @@ class ConstituencyPostcodeFinderView(ContributorsMixin, FormView):
 class ConstituencyNameFinderView(ContributorsMixin, FormView):
     template_name = 'candidates/finder.html'
     form_class = ConstituencyForm
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(ConstituencyNameFinderView, self).dispatch(*args, **kwargs)
 
     def form_valid(self, form):
         constituency_id = form.cleaned_data['constituency']


### PR DESCRIPTION
Having {% csrf_token %} in a template causes a cookie to be set when
viewing that page, which will mean pages of the site won't be cached
across different anonymous users because of Vary: Cookie header.

One option would be to change the postcode and constituency lookup
forms to have action="get" and leave out the CSRF token, but this
would mean some slightly complicated changes to the class-based
views; it's easiest just to exempt those views from CSRF protection
and remove the {% csrf_token %}.  (This shouldn't have any security
implication for these views, since they're just looking up public
information.)