### PR TITLE
Fix the "fix data" commands

### DIFF
--- a/candidates/management/commands/candidates_fix_image_metadata.py
+++ b/candidates/management/commands/candidates_fix_image_metadata.py
@@ -89,7 +89,6 @@ class Command(PopItApiMixin, BaseCommand):
             for image in person.get('images', []):
                 print "  Image with URL:", image['url']
                 fix_image(image)
-                image.pop('_id', None)
                 # Some images have an empty 'created' field, which
                 # causes an Elasticsearch indexing error, so remove
                 # that if it's the case:

--- a/candidates/management/commands/candidates_fix_image_metadata.py
+++ b/candidates/management/commands/candidates_fix_image_metadata.py
@@ -90,10 +90,10 @@ class Command(PopItApiMixin, BaseCommand):
                 print "  Image with URL:", image['url']
                 fix_image(image)
                 # Some images have an empty 'created' field, which
-                # causes an Elasticsearch indexing error, so remove
-                # that if it's the case:
+                # causes an Elasticsearch indexing error, so change it
+                # to null if that's the case:
                 if not image.get('created'):
-                    image.pop('created', None)
+                    image['created'] = None
             fix_dates(person)
             try:
                 self.api.persons(person['id']).put(person)

--- a/candidates/management/commands/candidates_remove_bogus_dates.py
+++ b/candidates/management/commands/candidates_remove_bogus_dates.py
@@ -35,7 +35,6 @@ class Command(PopItApiMixin, BaseCommand):
                 ]
             )
             for image in person.get('images', []):
-                image.pop('_id', None)
                 # Some images have an empty 'created' field, which
                 # causes an Elasticsearch indexing error, so remove
                 # that if it's the case:

--- a/candidates/management/commands/candidates_remove_bogus_dates.py
+++ b/candidates/management/commands/candidates_remove_bogus_dates.py
@@ -35,11 +35,6 @@ class Command(PopItApiMixin, BaseCommand):
                 ]
             )
             for image in person.get('images', []):
-                # Some images have an empty 'created' field, which
-                # causes an Elasticsearch indexing error, so remove
-                # that if it's the case:
-                if not image.get('created'):
-                    image.pop('created', None)
                 strip_bogus_fields(
                     image,
                     [
@@ -51,7 +46,6 @@ class Command(PopItApiMixin, BaseCommand):
                         'end_date'
                     ]
                 )
-            fix_dates(person)
             try:
                 self.api.persons(person['id']).put(person)
             except HttpClientError as e:

--- a/candidates/management/commands/candidates_remove_last_party_from_versions.py
+++ b/candidates/management/commands/candidates_remove_last_party_from_versions.py
@@ -27,7 +27,6 @@ class Command(PopItApiMixin, BaseCommand):
             if not needs_update:
                 continue
             for image in person.get('images', []):
-                image.pop('_id', None)
                 # Some images have an empty 'created' field, which
                 # causes an Elasticsearch indexing error, so remove
                 # that if it's the case:

--- a/candidates/management/commands/candidates_remove_last_party_from_versions.py
+++ b/candidates/management/commands/candidates_remove_last_party_from_versions.py
@@ -26,13 +26,6 @@ class Command(PopItApiMixin, BaseCommand):
                     del data['last_party']
             if not needs_update:
                 continue
-            for image in person.get('images', []):
-                # Some images have an empty 'created' field, which
-                # causes an Elasticsearch indexing error, so remove
-                # that if it's the case:
-                if not image.get('created'):
-                    image.pop('created', None)
-            fix_dates(person)
             try:
                 self.api.persons(person['id']).put(person)
             except HttpClientError as e:


### PR DESCRIPTION
These one-off scripts were introduced to fix problems in that data that
meant that indexing of people in Elasticsearch would fail, but had some
bugs in them. Now that https://github.com/mysociety/popit/issues/814 and
https://github.com/mysociety/popit/issues/794 are resolved, it's worth
fixing these so we can try again.

This is related to https://github.com/mysociety/yournextmp-popit/issues/295