### PR TITLE
Allow birth year as an alternative to full dob

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -7,6 +7,7 @@ from .static_data import MapItData, PartyData
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django_date_extensions.fields import ApproximateDateFormField
 
 from .mapit import get_wmc_from_postcode, BaseMapItException
 from .models import UserTermsAgreement
@@ -99,8 +100,8 @@ class BasePersonForm(forms.Form):
         max_length=256,
         required=False,
     )
-    birth_date = forms.DateField(
-        label="Date of birth (as YYYY-MM-DD)",
+    birth_date = ApproximateDateFormField(
+        label="Date of birth (as YYYY-MM-DD or YYYY)",
         required=False,
     )
     wikipedia_url = forms.URLField(

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -96,7 +96,11 @@
     <dt>Age</dt>
     {% with dob=person.date_of_birth %}
       {% if dob %}
-        <dd>{{ person.age }}<small class="dob">(Date of birth: {{ dob|date:"jS F Y" }})</small>
+        {% if dob|length_is:"4" %}
+          <dd>{{ person.age }}<small class="dob">(Year of birth: {{ dob }})</small>
+        {% else %}
+          <dd>{{ person.age }}<small class="dob">(Date of birth: {{ dob|date:"jS F Y" }})</small>
+        {% endif %}
       {% else %}
         <dd>Unknown
       {% endif %}</dd>

--- a/candidates/tests/test_create_person.py
+++ b/candidates/tests/test_create_person.py
@@ -22,7 +22,7 @@ class MinimalUpdateClass(PersonUpdateMixin, CandidacyMixin, PopItApiMixin):
 
 
 EXPECTED_ARGS = {
-    'birth_date': None,
+    'birth_date': '1988-01-01',
     'email': u'jane@example.org',
     'gender': 'female',
     'honorific_prefix': None,
@@ -91,7 +91,7 @@ EXPECTED_ARGS = {
                 'facebook_page_url': 'http://notreallyfacebook/tessajowellcampaign',
                 'facebook_personal_url': 'http://notreallyfacebook/tessajowell',
                 'party_ppc_page_url': 'http://labour.example.org/tessajowell',
-                'birth_date': None,
+                'birth_date': '1988-01-01',
                 'gender': 'female',
                 'name': 'Jane Doe',
                 'wikipedia_url': '',
@@ -138,6 +138,7 @@ NEW_PERSON_DATA = {
     "facebook_personal_url": "http://notreallyfacebook/tessajowell",
     "facebook_page_url": "http://notreallyfacebook/tessajowellcampaign",
     "party_ppc_page_url": "http://labour.example.org/tessajowell",
+    "birth_date": "1988-01-01",
 }
 
 @patch.object(FakePersonCollection, 'post')

--- a/candidates/tests/test_update_person.py
+++ b/candidates/tests/test_update_person.py
@@ -35,7 +35,7 @@ class TestUpdatePerson(TestCase):
         view.create_party_memberships = MagicMock()
 
         new_person_data = {
-            "birth_date": None,
+            "birth_date": '1947',
             "email": "foo@example.org",
             "homepage_url": "http://foo.example.org",
             "id": "2009",
@@ -102,7 +102,7 @@ class TestUpdatePerson(TestCase):
         self.assertEqual(2, len(mocked_put.call_args_list))
 
         first_put_call_args = {
-                'birth_date': None,
+                'birth_date': '1947',
                 'contact_details': [],
                 'email': u'foo@example.org',
                 'gender': None,
@@ -126,7 +126,7 @@ class TestUpdatePerson(TestCase):
             }
 
         second_put_call_args = {
-                'birth_date': None,
+                'birth_date': '1947',
                 'contact_details': [
                     {
                         'type': 'twitter',

--- a/candidates/update.py
+++ b/candidates/update.py
@@ -224,8 +224,14 @@ class PersonParseMixin(PopItApiMixin):
         # candidate's age in years:
         dob_str = person.popit_data.get('birth_date')
         if dob_str:
-            extra_for_template['date_of_birth'] = datetime.strptime(dob_str, '%Y-%m-%d').date()
-            extra_for_template['age'] = years_ago(extra_for_template['date_of_birth'], date.today())
+            dob_str = dob_str.replace('-00-00', '')
+            if len(dob_str) == 4:
+                extra_for_template['date_of_birth'] = dob_str
+                approx_age = date.today().year - int(dob_str)
+                extra_for_template['age'] = "{0} or {1}".format(approx_age - 1, approx_age)
+            else:
+               extra_for_template['date_of_birth'] = datetime.strptime(dob_str, '%Y-%m-%d').date()
+               extra_for_template['age'] = years_ago(extra_for_template['date_of_birth'], date.today())
         else:
             extra_for_template['date_of_birth'] = extra_for_template['age'] = ''
         extra_for_template['last_party'] = self.get_last_party(person.popit_data)

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -10,6 +10,7 @@ from django.utils.decorators import method_decorator
 from django.utils.http import urlquote
 from django.views.decorators.cache import cache_control
 from django.views.generic import FormView, TemplateView, View
+from django_date_extensions.fields import ApproximateDate
 
 from braces.views import LoginRequiredMixin
 
@@ -38,7 +39,7 @@ def copy_person_form_data(cleaned_data):
     # it into a string:
     birth_date_date = result['birth_date']
     if birth_date_date:
-        result['birth_date'] = str(birth_date_date)
+        result['birth_date'] = repr(birth_date_date).replace("-00-00", "")
     area_id = result.get('constituency')
     if area_id:
         country_name =  MapItData.constituencies_2010.get(area_id)['country_name']

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ coverage==3.7.1
 cryptography==0.8
 django-allauth==0.18.0
 django-braces==1.4.0
+django_date_extensions==0.1dev
 django-debug-toolbar==1.2.1
 django-nose==1.3
 django-pipeline==1.3.25


### PR DESCRIPTION
Allows the editing form to accept a date of birth or year of birth (the label still says 'Date of birth' but the help text will say 'YYYY-MM-DD or YYYY'.

As a result, age will be displayed as 'n-1 or n' if we've just got a year as we can't determine the exact age with any certainty (similar to Wikipedia behaviour but I can't find an example now that I want one).

Fixes #246 