### PR TITLE
Remove any dissolved parties from /numbers/parties

### DIFF
--- a/cached_counts/management/commands/cached_counts_create.py
+++ b/cached_counts/management/commands/cached_counts_create.py
@@ -74,6 +74,21 @@ class Command(PopItApiMixin, BaseCommand):
 
             self.add_or_update(obj)
 
+        # Remove any parties that have dissolved but still might have
+        # entries in the database:
+        parties_in_database = set(
+            CachedCount.objects.filter(count_type='party'). \
+                values_list('object_id', flat=True)
+        )
+        current_parties = set(
+            PartyData.party_id_to_name.keys()
+        )
+        parties_to_remove = parties_in_database - current_parties
+        CachedCount.objects.filter(
+            count_type='party',
+            object_id__in=parties_to_remove
+        ).delete()
+
         # Constituencies
         for constituency_id, data in counts['constituencies'].items():
             obj = {


### PR DESCRIPTION
We've made an effort recently to get rid of all the parties that are now
dissolved, and we now only consider the current parties when counting
numbers of candidates for each party. However, there will still be rows
in the cached_counts_cachedcount table that refer to now-dissolved
parties.

This commit introduces code to purge any such dissolved parties from the
cached_counts_cachedcount table when cached_counts_create is run.

Fixes #260