### PR TITLE
Add a permanent Noms upload link

### DIFF
--- a/candidates/templates/candidates/constituency.html
+++ b/candidates/templates/candidates/constituency.html
@@ -13,19 +13,25 @@
 {% block content %}
 
   <p>
-    {% for paper in nomination_papers %}
-      View the official Statement of Nominated Persons for this constituency:
-       <a href="{{ paper.get_absolute_url }}">{{ paper.document_type }}</a><br>
-    {% empty %}
+    {% if nomination_papers %}
+      {% for paper in nomination_papers %}
+        View the official Statement of Nominated Persons for this constituency:
+         <a href="{{ paper.get_absolute_url }}">{{ paper.document_type }}</a><br>
+      {% endfor %}
+      {% if user_can_upload_documents %}
+        <a href="{% url 'upload_document_view' mapit_area_id %}">
+        Upload an updated Statement of Nominated Persons</a>.
+      {% endif %}
+    {% else %}
       We don't have nomination papers for {{ constituency_name }} yet.
       Can you help us by <a href="https://docs.google.com/spreadsheets/d/1jvWaQSENnASZfGne1IWRbDATMH2NT2xutyPEbZ5Is-8/edit#gid=0">
         adding them to this google spreadsheet</a>?
       {% if user_can_upload_documents %}
-      Or, as you have permission to upload documents, you can
+        Or, as you have permission to upload documents, you can
         <a href="{% url 'upload_document_view' mapit_area_id %}">
         upload it directly</a>.
       {% endif %}
-    {% endfor %}
+    {% endif %}
   </p>
 
   {% if user_can_lock %}


### PR DESCRIPTION
Occasionally, statement of nominations are updated, and a new version needs to be uploaded e.g.
https://yournextmp.com/constituency/65845/bexhill-and-battle

To do this, you currently need to know the statement of nominations upload URL i.e.:
https://yournextmp.com/upload_document/upload/[constituency ID]/

A permanent link to this is therefore handy.