### PR TITLE
Use bleach to clean & linkify 'justification for use' text in photo review

### DIFF
--- a/moderation_queue/templates/moderation_queue/photo-review.html
+++ b/moderation_queue/templates/moderation_queue/photo-review.html
@@ -108,7 +108,7 @@
       {% if justification_for_use %}
         <p>
           {{ username }}'s justification for use of this photo was:
-          &#8220;{{ justification_for_use }}&#8221;
+          &#8220;{{ justification_for_use|safe }}&#8221;
         </p>
       {% endif %}
 

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -1,3 +1,4 @@
+import bleach
 import os
 import re
 import requests
@@ -152,7 +153,18 @@ class PhotoReview(GroupRequiredMixin, CandidacyMixin, PersonParseMixin, PersonUp
         )
         context['why_allowed'] = self.queued_image.why_allowed
         context['moderator_why_allowed'] = self.queued_image.why_allowed
-        context['justification_for_use'] = self.queued_image.justification_for_use
+        # There are often source links supplied in the justification,
+        # and it's convenient to be able to follow them. However, make
+        # sure that any maliciously added HTML tags have been stripped
+        # before linkifying any URLs:
+        context['justification_for_use'] = \
+            bleach.linkify(
+                bleach.clean(
+                    self.queued_image.justification_for_use,
+                    tags=[],
+                    strip=True
+                )
+            )
         context['google_image_search_url'] = self.get_google_image_search_url(
             context['person'], context['person_extra']
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 argparse==1.2.1
 beautifulsoup4==4.3.2
+bleach==1.4.1
 cffi==0.9.2
 coverage==3.7.1
 cryptography==0.8
@@ -15,6 +16,7 @@ docutils==0.10
 -e git+https://github.com/django-extensions/django-extensions.git@44a39ccd882b31381c3da63861d70f0b3b5690f8#egg=django-extensions
 enum34==1.0.4
 futures==2.1.6
+html5lib==0.999
 ipdb==0.8
 ipython==2.1.0
 jsonpatch==1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,9 @@
-Django==1.7.4
-Pillow==2.7.0
-PopIt-Python==0.1.10
-PyYAML==3.11
-South==1.0.1
-Unidecode==0.04.17
-WebOb==1.4
-WebTest==2.0.15
 argparse==1.2.1
 beautifulsoup4==4.3.2
 cffi==0.9.2
 coverage==3.7.1
 cryptography==0.8
+Django==1.7.4
 django-allauth==0.18.0
 django-braces==1.4.0
 django_date_extensions==0.1dev
@@ -19,9 +12,9 @@ django-nose==1.3
 django-pipeline==1.3.25
 django-webtest==1.7.7
 docutils==0.10
+-e git+https://github.com/django-extensions/django-extensions.git@44a39ccd882b31381c3da63861d70f0b3b5690f8#egg=django-extensions
 enum34==1.0.4
 futures==2.1.6
--e git+https://github.com/django-extensions/django-extensions.git@44a39ccd882b31381c3da63861d70f0b3b5690f8#egg=django-extensions
 ipdb==0.8
 ipython==2.1.0
 jsonpatch==1.9
@@ -32,20 +25,27 @@ ndg-httpsclient==0.3.3
 nose==1.3.4
 numpy==1.9.1
 oauthlib==0.6.3
+Pillow==2.7.0
+PopIt-Python==0.1.10
 psycopg2==2.5.4
-pyOpenSSL==0.14
 pyasn1==0.1.7
 pycparser==2.10
+pyOpenSSL==0.14
 python-dateutil==2.2
 python-magic==0.4.6
 python-memcached==1.54
 python-openid==2.2.5
 python-slugify==0.0.7
+PyYAML==3.11
 requests==2.6.0
 requests-oauthlib==0.4.1
 six==1.7.3
 slumber==0.6.0
+South==1.0.1
 sqlparse==0.1.11
+Unidecode==0.04.17
 waitress==0.8.9
+WebOb==1.4
+WebTest==2.0.15
 wsgiref==0.1.2
 yanc==0.2.4


### PR DESCRIPTION
It's useful to be able to follow links that people quote in the
"justification for use" box, but we have to sanitize anything in that
box before linkifying anything URL-like and marking it safe.
