### PR TITLE
Update Google Analytics for this being on a secondary domain

### DIFF
--- a/mysite/templates/base.html
+++ b/mysite/templates/base.html
@@ -37,7 +37,9 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', '{{ settings.GOOGLE_ANALYTICS_ACCOUNT }}', 'auto');
+        ga('create', '{{ settings.GOOGLE_ANALYTICS_ACCOUNT }}', 'auto', {'allowLinker': true});
+        ga('require', 'linker');
+        ga('linker:autoLink', ['yournextmp.com'] );
         ga('send', 'pageview');
 
       </script>


### PR DESCRIPTION
We're shortly going to move the crowd-sourcing interface to
edit.yournextmp.com while a static site is served at yournextmp.com.
This changes the Google Analytics tracking code as advised here:

  https://support.google.com/analytics/answer/1034342?hl=en

... for this site being the secondary domain to yournextmp.com

I'm unclear about whether it would be bad to deploy this before
changing this site to be edit.yournextmp.com (i.e. whether it would
lose us analytics events) but I would hope not.