### PR TITLE
Prevent any new user accounts from being created

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -78,3 +78,8 @@ MEDIA_ROOT: null
 # If this is true, you have to be in the 'Trusted to Rename' group in
 # order to change the name of a candidate:
 RESTRICT_RENAMES: false
+
+# If this is set to false, then no new accounts may be created - you
+# might want this past a certain point in the election to reduce
+# opportunities for "drive-by" malicious edits.
+NEW_ACCOUNTS_ALLOWED: true

--- a/mysite/account_adapter.py
+++ b/mysite/account_adapter.py
@@ -1,0 +1,14 @@
+from allauth.account.adapter import DefaultAccountAdapter
+
+class NoNewUsersAccountAdapter(DefaultAccountAdapter):
+
+    def is_open_for_signup(self, request):
+        """
+        Checks whether or not the site is open for signups.
+
+        Next to simply returning True/False you can also intervene the
+        regular flow by raising an ImmediateHttpResponse
+
+        (Comment reproduced from the overridden method.)
+        """
+        return False

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -140,7 +140,8 @@ ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = True
 SOCIALACCOUNT_AUTO_SIGNUP = True
-ACCOUNT_ADAPTER = 'mysite.account_adapter.NoNewUsersAccountAdapter'
+if not conf.get('NEW_ACCOUNTS_ALLOWED', True):
+    ACCOUNT_ADAPTER = 'mysite.account_adapter.NoNewUsersAccountAdapter'
 
 ROOT_URLCONF = 'mysite.urls'
 

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -140,6 +140,7 @@ ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = True
 SOCIALACCOUNT_AUTO_SIGNUP = True
+ACCOUNT_ADAPTER = 'mysite.account_adapter.NoNewUsersAccountAdapter'
 
 ROOT_URLCONF = 'mysite.urls'
 


### PR DESCRIPTION
As we get closer to the election and the site gets more attention, it
presumably is more likely to attract malicious editors. This commit
prevents new accounts from being created, but still allows existing
users to log in.