### PR TITLE
On party pages, only show every constituency for the biggest parties

### DIFF
--- a/candidates/templates/candidates/party.html
+++ b/candidates/templates/candidates/party.html
@@ -37,20 +37,25 @@
 
   {% endif %}
 
-  {% for country, constituencies in candidates_by_country %}
+  {% for country, country_data in candidates_by_country %}
     <h3>{{ country }}</h3>
-    {% if constituencies %}
+    {% if country_data.constituencies %}
       <ul>
-        {% for post_id, constituency_name, candidate in constituencies %}
+        {% for post_id, constituency_name, candidate in country_data.constituencies %}
           {% if candidate %}
             <li><a href="{% url 'person-view' person_id=candidate.person_id %}">{{ candidate.person_name }}</a>
               is standing in
               <a href="{% url 'constituency' mapit_area_id=post_id ignored_slug=constituency_name|slugify %}">{{ candidate.constituency_name }}</a></li>
-          {% else %}
+          {% elif country_data.stats.show_all %}
             <li>No candidate in <a href="{% url 'constituency' mapit_area_id=post_id ignored_slug=constituency_name|slugify %}">{{ constituency_name }}</a></li>
           {% endif %}
         {% endfor %}
       </ul>
+      {% if not country_data.stats.show_all %}
+        <p>There were also {{ country_data.stats.missing }} constituencies in
+          {{ country }} that {{ party_name }} aren't standing a candidate in.
+        </p>
+      {% endif %}
     {% else %}
       <p>We don't know of any {{ party_name }} candidates in {{ country }} so far.</p>
     {% endif %}

--- a/candidates/tests/test_party_pages.py
+++ b/candidates/tests/test_party_pages.py
@@ -87,9 +87,12 @@ class TestPartyPages(WebTest):
             u"We don't know of any Labour Party candidates in Northern Ireland so far.",
             unicode(response)
         )
-        # Check there's no David Miliband (since he's not standing in 2015):
-        self.assertIn(
-            u'<li>No candidate in <a href="/constituency/65719/south-shields">South Shields</a>',
+        # Check there's no mention of David Miliband's constituency
+        # (since he's not standing in 2015) and we've not added enough
+        # example candidates to reach the threshold where all
+        # constituencies should be shown:
+        self.assertNotIn(
+            u'South Shields',
             unicode(response)
         )
         # But there is an Ed Miliband:


### PR DESCRIPTION
It didn't make sense to just show a long list of constituencies saying
"no party standing here" for almost all of them, so this commit changes
the party pages so it only shows all constituencies in a country for
parties standing candidates in more than 30% of the seats there.