### PR TITLE
Use fieldname in default search

### DIFF
--- a/tasks/templates/tasks/field.html
+++ b/tasks/templates/tasks/field.html
@@ -24,10 +24,9 @@
     (<a href="{% url "person-update" person.id %}">edit</a>)
     ({{ person.party_memberships.2015.name }}, {{ person.standing_in.2015.name }})
     {% if person.versions.0.data.twitter_username %}
-        &mdash; <a href="https://twitter.com/intent/tweet?text=Hi @{{ person.versions.0.data.twitter_username }} could you add your campaign email to your YourNextMP.com page please? https://yournextmp.com/person/{{person.id}}/">
+        &mdash; <a href="https://twitter.com/intent/tweet?text=Hi @{{ person.versions.0.data.twitter_username }} could you add your {{ field }} to your YourNextMP.com page please? https://yournextmp.com/person/{{person.id}}/">
             Tweet them</a>{% endif %}
-    &mdash; <a href="https://duckduckgo.com/?q=%22{{ person.name }}%22+email">Search</a>
-    &mdash; <a href="https://duckduckgo.com/?q=%22{{ person.name }}%22+%22{{ person.standing_in.2015.name }}%22+email">Search name and constituency</a>
+    &mdash; <a href="https://duckduckgo.com/?q=%22{{ person.name }}%22+%22{{ person.standing_in.2015.name }}%22+{{ field }}">Search</a>
 </li>
 {% endfor %}
 


### PR DESCRIPTION
This also removes the search without constituency name – just
because I’m not really sure we need both.