### PR TITLE
Fetch any parlparse (TheyWorkForYou) IDs for newly elected MPs

### DIFF
--- a/candidates/management/commands/candidates_add_new_parlparse_ids.py
+++ b/candidates/management/commands/candidates_add_new_parlparse_ids.py
@@ -1,0 +1,56 @@
+import requests
+
+from django.core.management.base import BaseCommand, CommandError
+
+from candidates.models import PopItPerson
+from candidates.popit import create_popit_api_object
+from candidates.views.version_data import get_change_metadata
+
+class Command(BaseCommand):
+    args = "<person.js URL>"
+    help = "Find any new parlparse IDs from parlparse and add them"
+
+    def handle(self, *args, **options):
+        self.verbosity = int(options.get('verbosity', 1))
+        api = create_popit_api_object()
+        if len(args) != 1:
+            raise CommandError("You must provide a person.js URL")
+        person_js_url = args[0]
+        print "person_js_url:", person_js_url
+        people_data = requests.get(person_js_url).json()
+        for person_data in people_data['persons']:
+            twfy_person = PopItPerson.create_from_dict(person_data)
+            ynmp_id = twfy_person.get_identifier('yournextmp')
+            if not ynmp_id:
+                continue
+            parlparse_id = twfy_person.id
+            ynmp_person = PopItPerson.create_from_popit(api, ynmp_id)
+            existing_parlparse_id = ynmp_person.get_identifier('uk.org.publicwhip')
+            if existing_parlparse_id:
+                if existing_parlparse_id == parlparse_id:
+                    # That's fine, there's already the right parlparse ID
+                    pass
+                else:
+                    # Otherwise there's a mismatch, which needs investigation
+                    msg = "Warning: parlparse ID mismatch between YNMP {0} "
+                    msg += "and TWFY {1} for YNMP person {2}\n"
+                    self.stderr.write(
+                        msg.format(
+                            existing_parlparse_id,
+                            parlparse_id,
+                            ynmp_id,
+                        )
+                    )
+                continue
+            msg = "Updating the YourNextMP person {0} with parlparse_id {1}\n"
+            self.stdout.write(msg.format(ynmp_id, parlparse_id))
+            ynmp_person.set_identifier(
+                'uk.org.publicwhip',
+                parlparse_id,
+            )
+            change_metadata = get_change_metadata(
+                None, "Fetched a new parlparse ID"
+            )
+            ynmp_person.record_version(change_metadata)
+            ynmp_person.save_to_popit(api)
+            ynmp_person.invalidate_cache_entries()


### PR DESCRIPTION
We'd like to link through to the TheyWorkForYou pages for all new MPs
from YourNextMP, but for people who have never been in TheyWorkForYou
previously, we won't have a parlparse / TWFY ID for them. This script
will fetch parlparse's people.json and look for any people in there
who have a yournextmp identifier, and check that we have the correct
parlparse ID for that person, updating it if it was missing.