### PR TITLE
Make OpenGraph and Twitter metadata generic

### DIFF
--- a/candidates/templates/candidates/constituency.html
+++ b/candidates/templates/candidates/constituency.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-
 {% load i18n %}
 {% load metadescription %}
 {% load standing %}
@@ -7,25 +6,25 @@
 
 {% block extra_head %}
     <!-- Open Graph data -->
-    <meta property="og:title" content="Candidates (PPCs) for {{ post_label_shorter }} in the UK 2015 General Election" />
+    <meta property="og:title" content="{% blocktrans with election_name=election_data.name %}Candidates for {{ post_label_shorter }} in the {{ election_name }}{% endblocktrans %}" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="{{ request.build_absolute_uri }}" />
     <meta property="og:image" content="{{ 'img/logo.png'|static_image_path:request }}" />
     <meta property="og:image:height" content="80" />
     <meta property="og:image:width" content="80" />
-    <meta property="og:site_name" content="YourNextMP" />
-    <meta property="og:description" content="List of Candidates (PPCs) for {{ post_label_shorter }} in the UK 2015 General Election - find out more on YourNextMP">
-    <meta property="og:locale" content="en_GB" />
+    <meta property="og:site_name" content="{% trans "YourNextMP" %}" />
+    <meta property="og:description" content="{% blocktrans with election=election_data.name post=constituency_name %}List of Candidates for {{ post_label_shorter }} in the {{ election }}{% endblocktrans %} - {% trans "find out more on YourNextMP" %}">
+    <meta property="og:locale" content="{{ LOCALE }}" />
 
     <!-- Twitter card data -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@yournextmp" />
-    <meta name="twitter:title" content="Candidates (PPCs) for {{ post_label_shorter }} in the {{ election_data.name }}" />
+    <meta name="twitter:site" content="{% trans "@yournextmp" %}" />
+    <meta name="twitter:title" content="{% blocktrans with election=election_data.name post=constituency_name %}List of Candidates for {{ post_label_shorter }} in the {{ election }}{% endblocktrans %}" />
     <meta property="twitter:image" content="{{ 'img/logo.png'|static_image_path:request }}" />
     <meta property="twitter:image:height" content="120" />
     <meta property="twitter:image:width" content="120" />
     <meta name="twitter:url" content="{{ request.build_absolute_uri }}" />
-    <meta name="twitter:description" content="List of Candidates (PPCs) for {{ post_label_shorter }} in the {{ election_data.name }} - find out more on YourNextMP"  />
+    <meta name="twitter:description" content="{% blocktrans with election=election_data.name %}List of Candidates for {{ post_label_shorter }} in the {{ election }}{% endblocktrans %} - {% trans "find out more on YourNextMP" %}"  />
 {% endblock %}
 
 {% block body_class %}constituency{% endblock %}

--- a/candidates/templates/candidates/frontpage.html
+++ b/candidates/templates/candidates/frontpage.html
@@ -1,29 +1,28 @@
 {% extends 'base.html' %}
-
 {% load i18n %}
 {% load metadescription %}
 
 {% block extra_head %}
     <!-- Open Graph data -->
-    <meta property="og:title" content="YourNextMP" />
+    <meta property="og:title" content="{% trans "YourNextMP" %}" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="{{ request.build_absolute_uri }}" />
     <meta property="og:image" content="{{ 'img/logo.png'|static_image_path:request }}" />
     <meta property="og:image:height" content="80" />
     <meta property="og:image:width" content="80" />
-    <meta property="og:site_name" content="YourNextMP" />
-    <meta property="og:description" content="YourNextMP - The high quality source of free candidate data for the 2015 General Election">
-    <meta property="og:locale" content="en_GB" />
+    <meta property="og:site_name" content="{% trans "YourNextMP" %}" />
+    <meta property="og:description" content="{% trans "YourNextMP" %} - {% blocktrans with election_name=election_data.name %}{{ election_name }} candidates{% endblocktrans %}">
+    <meta property="og:locale" content="{{ LOCALE }}" />
 
     <!-- Twitter card data -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@yournextmp" />
-    <meta name="twitter:title" content="YourNextMP" />
+    <meta name="twitter:site" content="{% trans "@yournextmp" %}" />
+    <meta name="twitter:title" content="{% trans "YourNextMP" %}" />
     <meta property="twitter:image" content="{{ 'img/logo.png'|static_image_path:request }}" />
     <meta property="twitter:image:height" content="120" />
     <meta property="twitter:image:width" content="120" />
     <meta name="twitter:url" content="{{ request.build_absolute_uri }}" />
-    <meta name="twitter:description" content="YourNextMP - The high quality source of free candidate data for the 2015 General Election"  />
+    <meta name="twitter:description" content="{% trans "YourNextMP" %} - {% blocktrans with election_name=election_data.name %}{{ election_name }} candidates{% endblocktrans %}"  />
 {% endblock %}
 
 {% block body_class %}finder{% endblock %}

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -7,11 +7,9 @@
 {% load metadescription %}
 
 {% block extra_head %}
-  <link rel="canonical" href="{{ canonical_url }}" />
-
-  {% with last_cons=person.last_cons %}
+    <link rel="canonical" href="{{ canonical_url }}" />
     <!-- Open Graph data -->
-    <meta property="og:title" content="{{ person.name }}{% if last_cons %} - Candidate (PPC) for {{ last_cons.1.name }} in {{ last_cons.0 }}{% endif %}" />
+    <meta property="og:title" content="{{ person.name }}{% if last_election %} - {% blocktrans with post=constituency election=contested_election %}Candidate for {{ post }} in {{ election }}{% endblocktrans %}{% endif %}" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="{{ canonical_url }}" />
     {% if person.image %}
@@ -23,14 +21,14 @@
     {% endif %}
     <meta property="og:image:height" content="80" />
     <meta property="og:image:width" content="80" />
-    <meta property="og:site_name" content="YourNextMP" />
-    <meta property="og:description" content="{% metadescription person last_cons DATE_TODAY %}">
-    <meta property="og:locale" content="en_GB" />
+    <meta property="og:site_name" content="{% trans "YourNextMP" %}" />
+    <meta property="og:description" content="{% metadescription person person.last_cons DATE_TODAY %}">
+    <meta property="og:locale" content="{{ LOCALE }}" />
 
     <!-- Twitter card data -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@yournextmp" />
-    <meta name="twitter:title" content="{{ person.name }}{% if last_cons %} - Candidate (PPC) for {{ last_cons.1.name }} in {{ last_cons.0 }}{% endif %}" />
+    <meta name="twitter:site" content="{% trans "@yournextmp" %}" />
+    <meta name="twitter:title" content="{{ person.name }}{% if last_election %} - {% blocktrans with post=constituency election=contested_election %}Candidate for {{ post }} in {{ election }}{% endblocktrans %}{% endif %}" />
     {% if person.image %}
       <meta property="twitter:image" content="{{ person.image }}" />
     {% elif person.gender|lower == 'female' %}
@@ -41,8 +39,7 @@
     <meta property="twitter:image:width" content="160" />
     <meta property="twitter:image:height" content="160" />
     <meta name="twitter:url" content="{{ canonical_url }}" />
-    <meta name="twitter:description" content="{% metadescription person last_cons DATE_TODAY %}" />
-  {% endwith %}
+    <meta name="twitter:description" content="{% metadescription person person.last_cons DATE_TODAY %}" />
 {% endblock %}
 
 {% block body_class %}person{% endblock %}

--- a/candidates/templatetags/metadescription.py
+++ b/candidates/templatetags/metadescription.py
@@ -4,14 +4,14 @@ from django import template
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.utils.translation import ugettext as _
+from django.utils.translation import get_language
 
 register = template.Library()
 
 @register.simple_tag
 def metadescription(person, last_cons, today):
     if person.last_party:
-        last_party_name = person.last_party['name'].strip()
-        last_party_name = re.sub('^The ', 'the ', last_party_name)
+        last_party_name = format_party_name(person.last_party['name'])
         args = {
             'election': last_cons[0],
             'name': person.name,
@@ -19,13 +19,13 @@ def metadescription(person, last_cons, today):
             'post': last_cons[1]['name'],
         }
         if is_post_election(last_cons[0], today):
-            if last_party_name == "Independent":
+            if last_party_name == _("Independent") % args:
                 output = _("%(name)s stood as an independent candidate in %(post)s in %(election)s") % args
             else:
                 output = _("%(name)s stood for %(party)s in %(post)s in %(election)s") % args
         else:
-            if last_party_name == "Independent":
-                output = _("%(name)s is standing as an independent candidate in %(post)s in %(election)s") % args
+            if last_party_name == _("Independent") % args:
+                output = _("%(name)s is standing as an independent candidate in %(post)s in %(election)s")
             else:
                 output = _("%(name)s is standing for %(party)s in %(post)s in %(election)s") % args
     else:
@@ -36,6 +36,18 @@ def metadescription(person, last_cons, today):
 
 def is_post_election(election, today):
     return today > settings.ELECTIONS[election]['election_date']
+
+def format_party_name(party_name):
+    party_name = party_name.strip()
+    if get_language()[0:2] == "en":
+        # otherwise we end up with "the Independent", which sounds like
+        # they're standing for a newspaper
+        if party_name != "Independent":
+            party_name = re.sub('^The ', 'the ', party_name)
+            party_words = party_name.split()
+            if party_words[0] != "the":
+                return "the %s" % party_name
+    return party_name
 
 @register.filter
 def static_image_path(image_name, request):

--- a/candidates/views/frontpage.py
+++ b/candidates/views/frontpage.py
@@ -4,6 +4,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import FormView
+from django.conf import settings
 
 from candidates.models.address import check_address
 from .mixins import ContributorsMixin
@@ -34,4 +35,5 @@ class AddressFinderView(ContributorsMixin, FormView):
         context = super(AddressFinderView, self).get_context_data(**kwargs)
         context['top_users'] = self.get_leaderboards()[1]['rows'][:8]
         context['recent_actions'] = self.get_recent_changes_queryset()[:5]
+        context['election_data'] = settings.ELECTIONS_CURRENT[-1][1]
         return context

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -48,6 +48,13 @@ class PersonView(PopItApiMixin, TemplateView):
         context['redirect_after_login'] = urlquote(path)
         context['canonical_url'] = self.request.build_absolute_uri(path)
         context['person'] = self.person
+        context['last_election'] = self.person.last_cons
+        if self.person.last_cons:
+            context['constituency'] = self.person.last_cons[1]['name']
+            context['contested_election'] = self.person.last_cons[0]
+        else:
+            context['constituency'] = ''
+            context['contested_election'] = ''
         return context
 
     def get(self, request, *args, **kwargs):

--- a/elections/uk_general_election_2015/templates/candidates/finder.html
+++ b/elections/uk_general_election_2015/templates/candidates/finder.html
@@ -1,28 +1,28 @@
 {% extends 'base.html' %}
-
+{% load i18n %}
 {% load metadescription %}
 
 {% block extra_head %}
     <!-- Open Graph data -->
-    <meta property="og:title" content="YourNextMP" />
+    <meta property="og:title" content="{% trans "YourNextMP" %}" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="{{ request.build_absolute_uri }}" />
     <meta property="og:image" content="{{ 'img/logo.png'|static_image_path:request }}" />
     <meta property="og:image:height" content="80" />
     <meta property="og:image:width" content="80" />
-    <meta property="og:site_name" content="YourNextMP" />
-    <meta property="og:description" content="YourNextMP - The high quality source of free candidate data for the 2015 General Election">
-    <meta property="og:locale" content="en_GB" />
+    <meta property="og:site_name" content="{% trans "YourNextMP" %}" />
+    <meta property="og:description" content="{% blocktrans with election_name=election_data.name %}YourNextMP - {{ election_name }} candidates{% endblocktrans %}">
+    <meta property="og:locale" content="{{ LOCALE }}" />
 
     <!-- Twitter card data -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@yournextmp" />
-    <meta name="twitter:title" content="YourNextMP" />
+    <meta name="twitter:site" content="{% trans "@yournextmp" %}" />
+    <meta name="twitter:title" content="{% trans "YourNextMP" %}" />
     <meta property="twitter:image" content="{{ 'img/logo.png'|static_image_path:request }}" />
     <meta property="twitter:image:height" content="120" />
     <meta property="twitter:image:width" content="120" />
     <meta name="twitter:url" content="{{ request.build_absolute_uri }}" />
-    <meta name="twitter:description" content="YourNextMP - The high quality source of free candidate data for the 2015 General Election"  />
+    <meta name="twitter:description" content="{% blocktrans with election_name=election_data.name %}YourNextMP - {{ election_name }} candidates{% endblocktrans %}" />
 {% endblock %}
 
 {% block body_class %}finder{% endblock %}

--- a/elections/uk_general_election_2015/views/frontpage.py
+++ b/elections/uk_general_election_2015/views/frontpage.py
@@ -38,6 +38,7 @@ class ConstituencyPostcodeFinderView(ContributorsMixin, PopItApiMixin, FormView)
         context['show_name_form'] = False
         context['top_users'] = self.get_leaderboards()[1]['rows'][:8]
         context['recent_actions'] = self.get_recent_changes_queryset()[:5]
+        context['election_data'] = settings.ELECTIONS_CURRENT[-1][1]
         return context
 
 
@@ -66,4 +67,5 @@ class ConstituencyNameFinderView(ContributorsMixin, PopItApiMixin, FormView):
         context['show_name_form'] = True
         context['top_users'] = self.get_leaderboards()[1]['rows'][:8]
         context['recent_actions'] = self.get_recent_changes_queryset()[:5]
+        context['election_data'] = settings.ELECTIONS_CURRENT[-1][1]
         return context

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-24 09:35+0100\n"
+"POT-Creation-Date: 2015-06-24 18:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -262,7 +262,7 @@ msgstr ""
 msgid "Post-nominal letters (e.g. CBE, DSO, etc.)"
 msgstr ""
 
-#: candidates/forms.py:75 candidates/templates/candidates/person-view.html:113
+#: candidates/forms.py:75 candidates/templates/candidates/person-view.html:110
 msgid "Email"
 msgstr ""
 
@@ -1162,50 +1162,91 @@ msgid ""
 "constituency:"
 msgstr ""
 
-#: candidates/templates/candidates/constituency.html:33
+#: candidates/templates/candidates/constituency.html:9
+#: candidates/templates/candidates/constituency.html:32
 #, python-format
 msgid "Candidates for %(post_label_shorter)s in the %(election_name)s"
 msgstr ""
 
-#: candidates/templates/candidates/constituency.html:36
+#: candidates/templates/candidates/constituency.html:15
+#: candidates/templates/candidates/frontpage.html:7
+#: candidates/templates/candidates/frontpage.html:13
+#: candidates/templates/candidates/frontpage.html:14
+#: candidates/templates/candidates/frontpage.html:20
+#: candidates/templates/candidates/frontpage.html:25
+#: candidates/templates/candidates/person-view.html:24
+#: elections/uk_general_election_2015/templates/candidates/finder.html:7
+#: elections/uk_general_election_2015/templates/candidates/finder.html:13
+#: elections/uk_general_election_2015/templates/candidates/finder.html:20
+#: mysite/templates/generic_base.html:55
+msgid "YourNextMP"
+msgstr ""
+
+#: candidates/templates/candidates/constituency.html:16
+#: candidates/templates/candidates/constituency.html:22
+#: candidates/templates/candidates/constituency.html:27
+#, python-format
+msgid "List of Candidates for %(post_label_shorter)s in the %(election)s"
+msgstr ""
+
+#: candidates/templates/candidates/constituency.html:16
+#: candidates/templates/candidates/constituency.html:27
+#: candidates/templatetags/metadescription.py:34
+msgid "find out more on YourNextMP"
+msgstr ""
+
+#: candidates/templates/candidates/constituency.html:21
+#: candidates/templates/candidates/frontpage.html:19
+#: candidates/templates/candidates/person-view.html:30
+#: elections/uk_general_election_2015/templates/candidates/finder.html:19
+msgid "@yournextmp"
+msgstr ""
+
+#: candidates/templates/candidates/constituency.html:35
 #, python-format
 msgid ""
 "Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr ""
 
-#: candidates/templates/candidates/constituency.html:48
-#: candidates/templates/candidates/constituency.html:58
-#: candidates/templates/candidates/person-view.html:230
-#: candidates/templates/candidates/person-view.html:239
+#: candidates/templates/candidates/constituency.html:47
+#: candidates/templates/candidates/constituency.html:57
+#: candidates/templates/candidates/person-view.html:227
+#: candidates/templates/candidates/person-view.html:236
 msgid "Invalidate Cache"
 msgstr ""
 
-#: candidates/templates/candidates/constituency.html:49
+#: candidates/templates/candidates/constituency.html:48
 msgid ""
 "As a staff user, you can invalidate any cached data for this constituency. "
 "This may <em>occasionally</em> be necessary if the page is showing stale "
 "information for more than 10 seconds."
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:33
+#: candidates/templates/candidates/frontpage.html:14
+#: candidates/templates/candidates/frontpage.html:25
+#, python-format
+msgid "%(election_name)s candidates"
+msgstr ""
+
+#: candidates/templates/candidates/frontpage.html:32
 msgid "Find candidates to be your next representative"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:35
+#: candidates/templates/candidates/frontpage.html:34
 msgid ""
 "Don’t pay for a candidate database sold by a data vendor — it’s a waste of "
 "money."
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:45
+#: candidates/templates/candidates/frontpage.html:44
 msgid "Show candidates"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:54
+#: candidates/templates/candidates/frontpage.html:53
 msgid "This is a crowd-sourced database of election candidates."
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:58
+#: candidates/templates/candidates/frontpage.html:57
 #, python-format
 msgid ""
 "The database is transparently sourced and available as structured data, "
@@ -1214,25 +1255,25 @@ msgid ""
 "candidate details.</a>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:71
+#: candidates/templates/candidates/frontpage.html:70
 msgid "Recent changes"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:78
+#: candidates/templates/candidates/frontpage.html:77
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new "
 "candidate</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:84
+#: candidates/templates/candidates/frontpage.html:83
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> is creating a new candidate <span class="
 "\"when\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:90
+#: candidates/templates/candidates/frontpage.html:89
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> merged another candidate into <a href="
@@ -1240,7 +1281,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:96
+#: candidates/templates/candidates/frontpage.html:95
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> uploaded a photo of <a href="
@@ -1248,7 +1289,7 @@ msgid ""
 "\"when\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:102
+#: candidates/templates/candidates/frontpage.html:101
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> approved an uploaded photo of <a href="
@@ -1256,7 +1297,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:108
+#: candidates/templates/candidates/frontpage.html:107
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> rejected an uploaded photo of <a href="
@@ -1264,7 +1305,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:114
+#: candidates/templates/candidates/frontpage.html:113
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> reverted to an earlier version of <a href="
@@ -1272,7 +1313,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:120
+#: candidates/templates/candidates/frontpage.html:119
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> confirmed candidacy for <a href="
@@ -1280,7 +1321,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:126
+#: candidates/templates/candidates/frontpage.html:125
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> removed candidacy for <a href="
@@ -1288,21 +1329,21 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:132
+#: candidates/templates/candidates/frontpage.html:131
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> locked a constituency <span class=\"when"
 "\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:136
+#: candidates/templates/candidates/frontpage.html:135
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> unlocked a constituency <span class=\"when"
 "\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:140
+#: candidates/templates/candidates/frontpage.html:139
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> marked <a href=\"%(person_url)s"
@@ -1310,29 +1351,29 @@ msgid ""
 "ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:146
+#: candidates/templates/candidates/frontpage.html:145
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> updated <a href=\"%(person_url)s"
 "\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:155
+#: candidates/templates/candidates/frontpage.html:154
 msgid "Show more changes…"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:158
+#: candidates/templates/candidates/frontpage.html:157
 msgid "Top users this week"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:162
+#: candidates/templates/candidates/frontpage.html:161
 #, python-format
 msgid "%(count)s edit"
 msgid_plural "%(count)s edits"
 msgstr[0] ""
 msgstr[1] ""
 
-#: candidates/templates/candidates/frontpage.html:167
+#: candidates/templates/candidates/frontpage.html:166
 msgid "Show full leaderboard…"
 msgstr ""
 
@@ -1452,22 +1493,22 @@ msgid "Please check your information matches our requirements, below."
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:51
-#: candidates/templates/candidates/person-view.html:102
+#: candidates/templates/candidates/person-view.html:99
 msgid "Personal details:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:86
-#: candidates/templates/candidates/person-view.html:119
+#: candidates/templates/candidates/person-view.html:116
 msgid "Constituencies:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:124
-#: candidates/templates/candidates/person-view.html:132
+#: candidates/templates/candidates/person-view.html:129
 msgid "Links and social media:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:187
-#: candidates/templates/candidates/person-view.html:157
+#: candidates/templates/candidates/person-view.html:154
 msgid "Demographics:"
 msgstr ""
 
@@ -1582,143 +1623,145 @@ msgstr ""
 msgid "Revert"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:52
+#: candidates/templates/candidates/person-view.html:12
+#: candidates/templates/candidates/person-view.html:31
+#: candidates/templates/candidates/person-view.html:49
 #, python-format
 msgid "Candidate for %(post)s in %(election)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:71
+#: candidates/templates/candidates/person-view.html:68
 #, python-format
 msgid "Candidate for <a href=\"%(url)s\">%(post)s</a> in %(election)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:85
+#: candidates/templates/candidates/person-view.html:82
 #, python-format
 msgid "%(name)s was elected"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:87
+#: candidates/templates/candidates/person-view.html:84
 #, python-format
 msgid "%(name)s was not elected"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:96
+#: candidates/templates/candidates/person-view.html:93
 #, python-format
 msgid ""
 "We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by "
 "adding one</a>!"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:105
+#: candidates/templates/candidates/person-view.html:102
 msgid "Name"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:108
+#: candidates/templates/candidates/person-view.html:105
 msgid "Also known as"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:115
+#: candidates/templates/candidates/person-view.html:112
 msgid "Party"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:124
+#: candidates/templates/candidates/person-view.html:121
 #, python-format
 msgid "Contested in the %(election_name)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:126
+#: candidates/templates/candidates/person-view.html:123
 #, python-format
 msgid "Contesting in the %(election_name)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:139
+#: candidates/templates/candidates/person-view.html:136
 msgid "(personal profile)"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:142
+#: candidates/templates/candidates/person-view.html:139
 msgid "(campaign page)"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:147
+#: candidates/templates/candidates/person-view.html:144
 msgid "Homepage"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:149
+#: candidates/templates/candidates/person-view.html:146
 msgid "Wikipedia page"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:151
+#: candidates/templates/candidates/person-view.html:148
 msgid "LinkedIn page"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:153
+#: candidates/templates/candidates/person-view.html:150
 msgid "Party candidate page"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:160
+#: candidates/templates/candidates/person-view.html:157
 msgid "Gender"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:161
-#: candidates/templates/candidates/person-view.html:173
+#: candidates/templates/candidates/person-view.html:158
+#: candidates/templates/candidates/person-view.html:170
 msgid "Unknown"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:162
+#: candidates/templates/candidates/person-view.html:159
 msgid "Age"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:167
+#: candidates/templates/candidates/person-view.html:164
 #, python-format
 msgid "Year of birth: %(dob)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:170
+#: candidates/templates/candidates/person-view.html:167
 #, python-format
 msgid "Date of birth: %(dob)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:179
+#: candidates/templates/candidates/person-view.html:176
 msgid "Photo Credit:"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:196
+#: candidates/templates/candidates/person-view.html:193
 msgid "Improve this data!"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:198
+#: candidates/templates/candidates/person-view.html:195
 msgid "Our database is built by people like you."
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:199
+#: candidates/templates/candidates/person-view.html:196
 msgid ""
 "Please do add extra details about this candidate – it only takes a moment."
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:202
+#: candidates/templates/candidates/person-view.html:199
 msgid "Edit candidate"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:205
+#: candidates/templates/candidates/person-view.html:202
 msgid "Log in to edit"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:213
+#: candidates/templates/candidates/person-view.html:210
 msgid "Use this data!"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:214
+#: candidates/templates/candidates/person-view.html:211
 msgid "Open data JSON API:"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:222
+#: candidates/templates/candidates/person-view.html:219
 #, python-format
 msgid ""
 "More details about getting <a href=\"%(api_url)s\">the data</a> and <a href="
 "\"%(about_url)s\">its license</a>."
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:231
+#: candidates/templates/candidates/person-view.html:228
 msgid ""
 "As a staff user, you can invalidate any cached data for this user. This may "
 "<em>occasionally</em> be necessary if the page is showing stale information "
@@ -1884,6 +1927,11 @@ msgid ""
 "href=\"%(email)s\">%(email)s</a>."
 msgstr ""
 
+#: candidates/templatetags/metadescription.py:22
+#: candidates/templatetags/metadescription.py:27
+msgid "Independent"
+msgstr ""
+
 #: candidates/templatetags/metadescription.py:23
 #, python-format
 msgid "%(name)s stood as an independent candidate in %(post)s in %(election)s"
@@ -1903,10 +1951,6 @@ msgstr ""
 #: candidates/templatetags/metadescription.py:30
 #, python-format
 msgid "%(name)s is standing for %(party)s in %(post)s in %(election)s"
-msgstr ""
-
-#: candidates/templatetags/metadescription.py:34
-msgid "find out more on YourNextMP"
 msgstr ""
 
 #: candidates/templatetags/standing.py:17
@@ -1951,22 +1995,22 @@ msgstr ""
 msgid "Party not found"
 msgstr ""
 
-#: candidates/views/people.py:95
+#: candidates/views/people.py:102
 #, python-brace-format
 msgid "Couldn't find the version {0} of person {1}"
 msgstr ""
 
-#: candidates/views/people.py:131
+#: candidates/views/people.py:138
 #, python-brace-format
 msgid "Malformed person ID '{0}'"
 msgstr ""
 
-#: candidates/views/people.py:134
+#: candidates/views/people.py:141
 #, python-brace-format
 msgid "You can't merge a person ({0}) with themself ({1})"
 msgstr ""
 
-#: candidates/views/people.py:149
+#: candidates/views/people.py:156
 #, python-brace-format
 msgid "After merging person {0}"
 msgstr ""
@@ -2021,6 +2065,12 @@ msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:114
 msgid "Built by <a href=\"#\">Congreso Interactivo</a>."
+msgstr ""
+
+#: elections/uk_general_election_2015/templates/candidates/finder.html:14
+#: elections/uk_general_election_2015/templates/candidates/finder.html:25
+#, python-format
+msgid "YourNextMP - %(election_name)s candidates"
 msgstr ""
 
 #: moderation_queue/forms.py:29
@@ -2368,7 +2418,7 @@ msgstr ""
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr ""
 
-#: mysite/settings.py:346
+#: mysite/settings.py:347
 msgid ""
 "Please don't quote third-party candidate sites —\n"
 "we prefer URLs of news stories or official candidate pages."
@@ -2431,10 +2481,6 @@ msgstr ""
 
 #: mysite/templates/generic_base.html:32
 msgid "YourNextMP - 2015 UK general election candidates"
-msgstr ""
-
-#: mysite/templates/generic_base.html:55
-msgid "YourNextMP"
 msgstr ""
 
 #: mysite/templates/generic_base.html:106

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-24 09:35+0100\n"
+"POT-Creation-Date: 2015-06-24 18:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -263,7 +263,7 @@ msgstr ""
 msgid "Post-nominal letters (e.g. CBE, DSO, etc.)"
 msgstr ""
 
-#: candidates/forms.py:75 candidates/templates/candidates/person-view.html:113
+#: candidates/forms.py:75 candidates/templates/candidates/person-view.html:110
 msgid "Email"
 msgstr ""
 
@@ -1163,50 +1163,91 @@ msgid ""
 "constituency:"
 msgstr ""
 
-#: candidates/templates/candidates/constituency.html:33
+#: candidates/templates/candidates/constituency.html:9
+#: candidates/templates/candidates/constituency.html:32
 #, python-format
 msgid "Candidates for %(post_label_shorter)s in the %(election_name)s"
 msgstr ""
 
-#: candidates/templates/candidates/constituency.html:36
+#: candidates/templates/candidates/constituency.html:15
+#: candidates/templates/candidates/frontpage.html:7
+#: candidates/templates/candidates/frontpage.html:13
+#: candidates/templates/candidates/frontpage.html:14
+#: candidates/templates/candidates/frontpage.html:20
+#: candidates/templates/candidates/frontpage.html:25
+#: candidates/templates/candidates/person-view.html:24
+#: elections/uk_general_election_2015/templates/candidates/finder.html:7
+#: elections/uk_general_election_2015/templates/candidates/finder.html:13
+#: elections/uk_general_election_2015/templates/candidates/finder.html:20
+#: mysite/templates/generic_base.html:55
+msgid "YourNextMP"
+msgstr "YoQuieroSaber Investigación"
+
+#: candidates/templates/candidates/constituency.html:16
+#: candidates/templates/candidates/constituency.html:22
+#: candidates/templates/candidates/constituency.html:27
+#, python-format
+msgid "List of Candidates for %(post_label_shorter)s in the %(election)s"
+msgstr ""
+
+#: candidates/templates/candidates/constituency.html:16
+#: candidates/templates/candidates/constituency.html:27
+#: candidates/templatetags/metadescription.py:34
+msgid "find out more on YourNextMP"
+msgstr ""
+
+#: candidates/templates/candidates/constituency.html:21
+#: candidates/templates/candidates/frontpage.html:19
+#: candidates/templates/candidates/person-view.html:30
+#: elections/uk_general_election_2015/templates/candidates/finder.html:19
+msgid "@yournextmp"
+msgstr ""
+
+#: candidates/templates/candidates/constituency.html:35
 #, python-format
 msgid ""
 "Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr ""
 
-#: candidates/templates/candidates/constituency.html:48
-#: candidates/templates/candidates/constituency.html:58
-#: candidates/templates/candidates/person-view.html:230
-#: candidates/templates/candidates/person-view.html:239
+#: candidates/templates/candidates/constituency.html:47
+#: candidates/templates/candidates/constituency.html:57
+#: candidates/templates/candidates/person-view.html:227
+#: candidates/templates/candidates/person-view.html:236
 msgid "Invalidate Cache"
 msgstr ""
 
-#: candidates/templates/candidates/constituency.html:49
+#: candidates/templates/candidates/constituency.html:48
 msgid ""
 "As a staff user, you can invalidate any cached data for this constituency. "
 "This may <em>occasionally</em> be necessary if the page is showing stale "
 "information for more than 10 seconds."
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:33
+#: candidates/templates/candidates/frontpage.html:14
+#: candidates/templates/candidates/frontpage.html:25
+#, python-format
+msgid "%(election_name)s candidates"
+msgstr ""
+
+#: candidates/templates/candidates/frontpage.html:32
 msgid "Find candidates to be your next representative"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:35
+#: candidates/templates/candidates/frontpage.html:34
 msgid ""
 "Don’t pay for a candidate database sold by a data vendor — it’s a waste of "
 "money."
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:45
+#: candidates/templates/candidates/frontpage.html:44
 msgid "Show candidates"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:54
+#: candidates/templates/candidates/frontpage.html:53
 msgid "This is a crowd-sourced database of election candidates."
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:58
+#: candidates/templates/candidates/frontpage.html:57
 #, python-format
 msgid ""
 "The database is transparently sourced and available as structured data, "
@@ -1215,25 +1256,25 @@ msgid ""
 "candidate details.</a>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:71
+#: candidates/templates/candidates/frontpage.html:70
 msgid "Recent changes"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:78
+#: candidates/templates/candidates/frontpage.html:77
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new "
 "candidate</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:84
+#: candidates/templates/candidates/frontpage.html:83
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> is creating a new candidate <span class="
 "\"when\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:90
+#: candidates/templates/candidates/frontpage.html:89
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> merged another candidate into <a href="
@@ -1241,7 +1282,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:96
+#: candidates/templates/candidates/frontpage.html:95
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> uploaded a photo of <a href="
@@ -1249,7 +1290,7 @@ msgid ""
 "\"when\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:102
+#: candidates/templates/candidates/frontpage.html:101
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> approved an uploaded photo of <a href="
@@ -1257,7 +1298,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:108
+#: candidates/templates/candidates/frontpage.html:107
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> rejected an uploaded photo of <a href="
@@ -1265,7 +1306,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:114
+#: candidates/templates/candidates/frontpage.html:113
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> reverted to an earlier version of <a href="
@@ -1273,7 +1314,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:120
+#: candidates/templates/candidates/frontpage.html:119
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> confirmed candidacy for <a href="
@@ -1281,7 +1322,7 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:126
+#: candidates/templates/candidates/frontpage.html:125
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> removed candidacy for <a href="
@@ -1289,21 +1330,21 @@ msgid ""
 "%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:132
+#: candidates/templates/candidates/frontpage.html:131
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> locked a constituency <span class=\"when"
 "\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:136
+#: candidates/templates/candidates/frontpage.html:135
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> unlocked a constituency <span class=\"when"
 "\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:140
+#: candidates/templates/candidates/frontpage.html:139
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> marked <a href=\"%(person_url)s"
@@ -1311,29 +1352,29 @@ msgid ""
 "ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:146
+#: candidates/templates/candidates/frontpage.html:145
 #, python-format
 msgid ""
 "User <strong>%(username)s</strong> updated <a href=\"%(person_url)s"
 "\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:155
+#: candidates/templates/candidates/frontpage.html:154
 msgid "Show more changes…"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:158
+#: candidates/templates/candidates/frontpage.html:157
 msgid "Top users this week"
 msgstr ""
 
-#: candidates/templates/candidates/frontpage.html:162
+#: candidates/templates/candidates/frontpage.html:161
 #, python-format
 msgid "%(count)s edit"
 msgid_plural "%(count)s edits"
 msgstr[0] ""
 msgstr[1] ""
 
-#: candidates/templates/candidates/frontpage.html:167
+#: candidates/templates/candidates/frontpage.html:166
 msgid "Show full leaderboard…"
 msgstr ""
 
@@ -1453,22 +1494,22 @@ msgid "Please check your information matches our requirements, below."
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:51
-#: candidates/templates/candidates/person-view.html:102
+#: candidates/templates/candidates/person-view.html:99
 msgid "Personal details:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:86
-#: candidates/templates/candidates/person-view.html:119
+#: candidates/templates/candidates/person-view.html:116
 msgid "Constituencies:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:124
-#: candidates/templates/candidates/person-view.html:132
+#: candidates/templates/candidates/person-view.html:129
 msgid "Links and social media:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:187
-#: candidates/templates/candidates/person-view.html:157
+#: candidates/templates/candidates/person-view.html:154
 msgid "Demographics:"
 msgstr ""
 
@@ -1583,143 +1624,145 @@ msgstr ""
 msgid "Revert"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:52
+#: candidates/templates/candidates/person-view.html:12
+#: candidates/templates/candidates/person-view.html:31
+#: candidates/templates/candidates/person-view.html:49
 #, python-format
 msgid "Candidate for %(post)s in %(election)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:71
+#: candidates/templates/candidates/person-view.html:68
 #, python-format
 msgid "Candidate for <a href=\"%(url)s\">%(post)s</a> in %(election)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:85
+#: candidates/templates/candidates/person-view.html:82
 #, python-format
 msgid "%(name)s was elected"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:87
+#: candidates/templates/candidates/person-view.html:84
 #, python-format
 msgid "%(name)s was not elected"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:96
+#: candidates/templates/candidates/person-view.html:93
 #, python-format
 msgid ""
 "We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by "
 "adding one</a>!"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:105
+#: candidates/templates/candidates/person-view.html:102
 msgid "Name"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:108
+#: candidates/templates/candidates/person-view.html:105
 msgid "Also known as"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:115
+#: candidates/templates/candidates/person-view.html:112
 msgid "Party"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:124
+#: candidates/templates/candidates/person-view.html:121
 #, python-format
 msgid "Contested in the %(election_name)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:126
+#: candidates/templates/candidates/person-view.html:123
 #, python-format
 msgid "Contesting in the %(election_name)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:139
+#: candidates/templates/candidates/person-view.html:136
 msgid "(personal profile)"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:142
+#: candidates/templates/candidates/person-view.html:139
 msgid "(campaign page)"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:147
+#: candidates/templates/candidates/person-view.html:144
 msgid "Homepage"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:149
+#: candidates/templates/candidates/person-view.html:146
 msgid "Wikipedia page"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:151
+#: candidates/templates/candidates/person-view.html:148
 msgid "LinkedIn page"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:153
+#: candidates/templates/candidates/person-view.html:150
 msgid "Party candidate page"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:160
+#: candidates/templates/candidates/person-view.html:157
 msgid "Gender"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:161
-#: candidates/templates/candidates/person-view.html:173
+#: candidates/templates/candidates/person-view.html:158
+#: candidates/templates/candidates/person-view.html:170
 msgid "Unknown"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:162
+#: candidates/templates/candidates/person-view.html:159
 msgid "Age"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:167
+#: candidates/templates/candidates/person-view.html:164
 #, python-format
 msgid "Year of birth: %(dob)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:170
+#: candidates/templates/candidates/person-view.html:167
 #, python-format
 msgid "Date of birth: %(dob)s"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:179
+#: candidates/templates/candidates/person-view.html:176
 msgid "Photo Credit:"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:196
+#: candidates/templates/candidates/person-view.html:193
 msgid "Improve this data!"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:198
+#: candidates/templates/candidates/person-view.html:195
 msgid "Our database is built by people like you."
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:199
+#: candidates/templates/candidates/person-view.html:196
 msgid ""
 "Please do add extra details about this candidate – it only takes a moment."
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:202
+#: candidates/templates/candidates/person-view.html:199
 msgid "Edit candidate"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:205
+#: candidates/templates/candidates/person-view.html:202
 msgid "Log in to edit"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:213
+#: candidates/templates/candidates/person-view.html:210
 msgid "Use this data!"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:214
+#: candidates/templates/candidates/person-view.html:211
 msgid "Open data JSON API:"
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:222
+#: candidates/templates/candidates/person-view.html:219
 #, python-format
 msgid ""
 "More details about getting <a href=\"%(api_url)s\">the data</a> and <a href="
 "\"%(about_url)s\">its license</a>."
 msgstr ""
 
-#: candidates/templates/candidates/person-view.html:231
+#: candidates/templates/candidates/person-view.html:228
 msgid ""
 "As a staff user, you can invalidate any cached data for this user. This may "
 "<em>occasionally</em> be necessary if the page is showing stale information "
@@ -1885,6 +1928,11 @@ msgid ""
 "href=\"%(email)s\">%(email)s</a>."
 msgstr ""
 
+#: candidates/templatetags/metadescription.py:22
+#: candidates/templatetags/metadescription.py:27
+msgid "Independent"
+msgstr ""
+
 #: candidates/templatetags/metadescription.py:23
 #, python-format
 msgid "%(name)s stood as an independent candidate in %(post)s in %(election)s"
@@ -1904,10 +1952,6 @@ msgstr ""
 #: candidates/templatetags/metadescription.py:30
 #, python-format
 msgid "%(name)s is standing for %(party)s in %(post)s in %(election)s"
-msgstr ""
-
-#: candidates/templatetags/metadescription.py:34
-msgid "find out more on YourNextMP"
 msgstr ""
 
 #: candidates/templatetags/standing.py:17
@@ -1952,22 +1996,22 @@ msgstr ""
 msgid "Party not found"
 msgstr ""
 
-#: candidates/views/people.py:95
+#: candidates/views/people.py:102
 #, python-brace-format
 msgid "Couldn't find the version {0} of person {1}"
 msgstr ""
 
-#: candidates/views/people.py:131
+#: candidates/views/people.py:138
 #, python-brace-format
 msgid "Malformed person ID '{0}'"
 msgstr ""
 
-#: candidates/views/people.py:134
+#: candidates/views/people.py:141
 #, python-brace-format
 msgid "You can't merge a person ({0}) with themself ({1})"
 msgstr ""
 
-#: candidates/views/people.py:149
+#: candidates/views/people.py:156
 #, python-brace-format
 msgid "After merging person {0}"
 msgstr ""
@@ -2001,8 +2045,10 @@ msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:66
 #: mysite/templates/generic_base.html:65
+#, fuzzy
+#| msgid "Sign Out"
 msgid "Sign out"
-msgstr ""
+msgstr "Cerrar sesión"
 
 #: elections/ar_elections_2015/templates/base.html:69
 #: mysite/templates/generic_base.html:69
@@ -2022,6 +2068,12 @@ msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:114
 msgid "Built by <a href=\"#\">Congreso Interactivo</a>."
+msgstr ""
+
+#: elections/uk_general_election_2015/templates/candidates/finder.html:14
+#: elections/uk_general_election_2015/templates/candidates/finder.html:25
+#, python-format
+msgid "YourNextMP - %(election_name)s candidates"
 msgstr ""
 
 #: moderation_queue/forms.py:29
@@ -2369,7 +2421,7 @@ msgstr ""
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr ""
 
-#: mysite/settings.py:346
+#: mysite/settings.py:347
 msgid ""
 "Please don't quote third-party candidate sites —\n"
 "we prefer URLs of news stories or official candidate pages."
@@ -2441,10 +2493,6 @@ msgstr ""
 #: mysite/templates/generic_base.html:32
 msgid "YourNextMP - 2015 UK general election candidates"
 msgstr ""
-
-#: mysite/templates/generic_base.html:55
-msgid "YourNextMP"
-msgstr "YoQuieroSaber Investigación"
 
 #: mysite/templates/generic_base.html:106
 msgid "Issue tracker"

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -9,6 +9,7 @@ from candidates.models import (
 )
 from moderation_queue.models import QueuedImage, PHOTO_REVIEWERS_GROUP_NAME
 from official_documents.models import DOCUMENT_UPLOADERS_GROUP_NAME
+from django.utils.translation import to_locale, get_language
 
 SETTINGS_TO_ADD = (
     'GOOGLE_ANALYTICS_ACCOUNT',
@@ -38,6 +39,12 @@ def election_date(request):
     return {
         'DATE_TODAY': date.today(),
     }
+
+
+def locale(request):
+    """Convert the language string to a locale"""
+    """Copied from: http://stackoverflow.com/a/6362929 """
+    return {'LOCALE': to_locale(get_language())}
 
 
 def add_notification_data(request):

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -85,6 +85,7 @@ TEMPLATE_CONTEXT_PROCESSORS += (
     "mysite.context_processors.election_date",
     "mysite.context_processors.add_group_permissions",
     "mysite.context_processors.add_notification_data",
+    "mysite.context_processors.locale",
 )
 
 ELECTION_APP = conf['ELECTION_APP']


### PR DESCRIPTION
Adds per app `SITE_NAME`, `SITE_DESC `, `SITE_TWITTER` and `SITE_LOCALE` settings which are used in the Twitter and OpenGraph metadata rather than hardcoding "General Election", "en_GB" etc

Also removes "(PPCs) " from the metadata text.

Closes #383