### PR TITLE
Fix the add candidate button

### DIFF
--- a/candidates/example-popit-data/posts_65730_embed=membership.person.membership.organization.json
+++ b/candidates/example-popit-data/posts_65730_embed=membership.person.membership.organization.json
@@ -1,0 +1,19 @@
+{
+  "result": {
+    "area": {
+      "id": "mapit:65730",
+      "identifier": "http://mapit.mysociety.org/area/65730",
+      "name": "Aldershot"
+    },
+    "contact_details": [],
+    "html_url": "http://candidates.127.0.0.1.xip.io:3000/posts/65730",
+    "id": "65730",
+    "label": "Member of Parliament for Aldershot",
+    "links": [],
+    "memberships": [],
+    "organization_id": "commons",
+    "role": "Member of Parliament",
+    "start_date": "2005-05-06",
+    "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/posts/65730"
+  }
+}

--- a/candidates/templates/candidates/_candidates_for_post.html
+++ b/candidates/templates/candidates/_candidates_for_post.html
@@ -129,7 +129,11 @@
         <p class="medium-8 columns">{% blocktrans trimmed with post_label=post_data.label election_name=election_data.name %}
             <strong>Oh no!</strong> We don’t know of any candidates in {{ post_label }}
         for the {{ election_name }} yet.{% endblocktrans %}</p>
-        <p class="medium-4 columns"><a class="show-new-candidate-form button">{% trans "Add a new candidate" %}</a></p>
+        {% if candidate_list_edits_allowed %}
+          <p class="medium-4 columns"><a class="show-new-candidate-form button">{% trans "Add a new candidate" %}</a></p>
+        {% else %}
+          <p class="medium-4 columns"><a href="{% url 'account_login' %}{% if redirect_after_login %}?next={{ redirect_after_login }}{% endif %}" class="show-new-candidate-form button">{% trans "Sign in to add a new candidate" %}</a></p>
+        {% endif %}
       </div>
     {% endfor %}
 

--- a/candidates/tests/test_areas_view.py
+++ b/candidates/tests/test_areas_view.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from mock import patch
 import re
 
@@ -289,6 +291,45 @@ class TestAreasView(TestUserMixin, WebTest):
 
         # should not allow recording the winner from this page
         self.assertNotIn('This candidate won!', response)
+
+
+    def test_no_candidates_without_login(self, mock_popit):
+        mock_popit.return_value.organizations = FakeOrganizationCollection
+        mock_popit.return_value.persons = FakePersonCollection
+        mock_popit.return_value.posts = FakePostCollection
+
+        response = self.app.get('/areas/WMC-65730/aldershot')
+
+        # should see the no candidates message
+        self.assertIn('We don’t know of any candidates', response)
+
+        # should be invited to sign in to add a candidate
+        self.assertFalse(
+            response.html.find(
+                'a', {'text': 'Sign in to add a new candidate'}
+            )
+        )
+
+
+    def test_no_candidates_with_login(self, mock_popit):
+        mock_popit.return_value.organizations = FakeOrganizationCollection
+        mock_popit.return_value.persons = FakePersonCollection
+        mock_popit.return_value.posts = FakePostCollection
+
+        response = self.app.get(
+            '/areas/WMC-65730/aldershot',
+            user=self.user
+        )
+
+        # should see the no candidates message
+        self.assertIn('We don’t know of any candidates', response)
+
+        # should be invited to add a candidate
+        self.assertFalse(
+            response.html.find(
+                'a', {'text': 'Add a new candidate'}
+            )
+        )
 
 
     def test_get_malformed_url(self, mock_popit):

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-25 09:53-0300\n"
+"POT-Creation-Date: 2015-06-30 17:59+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -449,40 +449,35 @@ msgstr ""
 msgid "given max_id is lower than the previous one ({0} vs {1})"
 msgstr ""
 
-#: candidates/models/popit.py:157
+#: candidates/models/popit.py:158
 #, python-brace-format
 msgid "Couldn't parse '{0}' as an ApproximateDate"
 msgstr ""
 
-#: candidates/models/popit.py:194
+#: candidates/models/popit.py:195
 #, python-brace-format
 msgid "Unknown partial ISO 8601 data format: {0}"
 msgstr ""
 
-#: candidates/models/popit.py:283
+#: candidates/models/popit.py:281
 #, python-brace-format
 msgid "Failed to parse the MapIt URL: {0}"
 msgstr ""
 
-#: candidates/models/popit.py:533
+#: candidates/models/popit.py:531
 #, python-brace-format
 msgid "'PopItPerson' has no attribute '{0}'"
 msgstr ""
 
-#: candidates/models/popit.py:586
+#: candidates/models/popit.py:584
 msgid "There was no previous version of this person"
 msgstr ""
 
-#: candidates/models/popit.py:771
-#, python-brace-format
-msgid "Malformed parlparse ID found {0}"
-msgstr ""
-
-#: candidates/models/popit.py:1191
+#: candidates/models/popit.py:1194
 msgid "Can't set_elected of a candidate with no standing_in"
 msgstr ""
 
-#: candidates/models/popit.py:1194
+#: candidates/models/popit.py:1197
 #, python-brace-format
 msgid "No standing_in information for {0}"
 msgstr ""
@@ -492,99 +487,103 @@ msgstr ""
 msgid "Found multiple areas for the post ID {post_id}"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:64
+#: candidates/templates/candidates/_candidates_for_post.html:65
 msgid "(This list of candidates is currently <strong>locked</strong>.)"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:66
+#: candidates/templates/candidates/_candidates_for_post.html:67
 msgid "(This list of candidates is currently <strong>unlocked</strong>.)"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:71
+#: candidates/templates/candidates/_candidates_for_post.html:72
 msgid ""
 "This list of candidates is now <strong>locked</strong>; you can still update "
 "contact details of candidates, but can't change the people standing in this "
 "constituency."
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:80
+#: candidates/templates/candidates/_candidates_for_post.html:81
 msgid "Unset the current winner, if incorrect"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:88
+#: candidates/templates/candidates/_candidates_for_post.html:89
 #, python-format
 msgid "Known candidates for <a href=\"%(post_url)s\">%(post_label)s</a>"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:98
+#: candidates/templates/candidates/_candidates_for_post.html:99
 msgid "Winner"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:105
+#: candidates/templates/candidates/_candidates_for_post.html:106
 msgid "Not actually standing?"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:107
-#: candidates/templates/candidates/_candidates_for_post.html:183
-#: candidates/templates/candidates/_candidates_for_post.html:211
+#: candidates/templates/candidates/_candidates_for_post.html:108
+#: candidates/templates/candidates/_candidates_for_post.html:188
+#: candidates/templates/candidates/_candidates_for_post.html:216
 msgid "Edit"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:117
+#: candidates/templates/candidates/_candidates_for_post.html:118
 msgid "[Quick update from the constituency page]"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:118
+#: candidates/templates/candidates/_candidates_for_post.html:119
 msgid "This candidate won!"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:128
+#: candidates/templates/candidates/_candidates_for_post.html:129
 #, python-format
 msgid ""
 "<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s "
 "for the %(election_name)s yet."
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:131
-#: candidates/templates/candidates/_candidates_for_post.html:136
-#: candidates/templates/candidates/_candidates_for_post.html:144
+#: candidates/templates/candidates/_candidates_for_post.html:133
+#: candidates/templates/candidates/_candidates_for_post.html:141
+#: candidates/templates/candidates/_candidates_for_post.html:149
 #: candidates/templates/candidates/person-create.html:7
 msgid "Add a new candidate"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:155
+#: candidates/templates/candidates/_candidates_for_post.html:135
+msgid "Sign in to add a new candidate"
+msgstr ""
+
+#: candidates/templates/candidates/_candidates_for_post.html:160
 msgid "Add new candidate"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:156
+#: candidates/templates/candidates/_candidates_for_post.html:161
 #: candidates/templates/candidates/record-winner.html:35
 #: moderation_queue/templates/moderation_queue/photo-review.html:158
 msgid "Cancel"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:168
+#: candidates/templates/candidates/_candidates_for_post.html:173
 msgid "Is a candidate from the 2010 election standing again?"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:170
+#: candidates/templates/candidates/_candidates_for_post.html:175
 msgid ""
 "We don't know if these candidates from earlier elections are standing again"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:180
+#: candidates/templates/candidates/_candidates_for_post.html:185
 msgid "Standing again"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:181
+#: candidates/templates/candidates/_candidates_for_post.html:186
 msgid "Not standing again"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:200
+#: candidates/templates/candidates/_candidates_for_post.html:205
 msgid ""
 "These candidates from earlier elections are known not to be standing again"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:209
+#: candidates/templates/candidates/_candidates_for_post.html:214
 msgid "Actually, they are standing!"
 msgstr ""
 
@@ -1102,8 +1101,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Before updating our records we need to know the source for your information "
-"that %(name)s is standing for election in the 2015 general election in "
-"%(constituency)s."
+"that %(name)s is standing for election to the post of %(post_label)s in the "
+"%(election_name)s."
 msgstr ""
 
 #: candidates/templates/candidates/candidacy-delete.html:6
@@ -1115,8 +1114,9 @@ msgstr ""
 #: candidates/templates/candidates/candidacy-delete.html:14
 #, python-format
 msgid ""
-"your information that %(name)s <strong>isn’t</strong> standing for election "
-"in the 2015 general election in %(constituency)s."
+"Before updating our records we need to know the source for your information "
+"that %(name)s <strong>isn’t</strong> standing for election to the post of "
+"%(post_label)s in the %(election_name)s."
 msgstr ""
 
 #: candidates/templates/candidates/constituencies-declared.html:6
@@ -1966,7 +1966,7 @@ msgstr ""
 msgid "Not standing"
 msgstr ""
 
-#: candidates/views/areas.py:24
+#: candidates/views/areas.py:24 candidates/views/areas.py:30
 #, python-brace-format
 msgid "Malformed type and area: '{0}'"
 msgstr ""
@@ -1975,11 +1975,11 @@ msgstr ""
 msgid "Attempt to edit a candidacy in a locked constituency"
 msgstr ""
 
-#: candidates/views/constituencies.py:191
+#: candidates/views/constituencies.py:195
 msgid "Invalid data POSTed to ConstituencyLockView"
 msgstr ""
 
-#: candidates/views/constituencies.py:333
+#: candidates/views/constituencies.py:338
 msgid "Result recorded in error, retracting"
 msgstr ""
 
@@ -2418,7 +2418,7 @@ msgstr ""
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr ""
 
-#: mysite/settings.py:347
+#: mysite/settings.py:362
 msgid ""
 "Please don't quote third-party candidate sites —\n"
 "we prefer URLs of news stories or official candidate pages."

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Martín Szyszlican <martinsz@gmail.com>, 2015
 # violeta gau <violetagau@gmail.com>, 2015
@@ -9,14 +9,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YourNextMP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-25 09:53-0300\n"
+"POT-Creation-Date: 2015-06-30 17:59+0100\n"
 "PO-Revision-Date: 2015-06-25 12:56+0000\n"
 "Last-Translator: mySociety <transifex@mysociety.org>\n"
-"Language-Team: Spanish (Argentina) (http://www.transifex.com/projects/p/yournextmp/language/es_AR/)\n"
+"Language-Team: Spanish (Argentina) (http://www.transifex.com/projects/p/"
+"yournextmp/language/es_AR/)\n"
+"Language: es_AR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es_AR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: auth_helpers/templates/auth_helpers/group_permission_denied.html:6
@@ -29,7 +30,10 @@ msgid ""
 "You must be in the member of a particular group in order to view that page. "
 "Please contact the administrators of the site if you feel that you should "
 "have access to this page."
-msgstr "Debe ser el administrador de un grupo particular para poder acceder a la página. Por favor contacte a los administradores del sitio si siente que debe tener acceso a esta página."
+msgstr ""
+"Debe ser el administrador de un grupo particular para poder acceder a la "
+"página. Por favor contacte a los administradores del sitio si siente que "
+"debe tener acceso a esta página."
 
 #: cached_counts/templates/constituency_counts.html:5
 #, python-format
@@ -110,14 +114,18 @@ msgstr "Candidatos que también se presentaron en %(prior_election_name)s:"
 msgid ""
 "Candidates standing again from the %(prior_election_name)s for the same "
 "party:"
-msgstr "Candidatos que también se presentaron en %(prior_election_name)s por el mismo partido:"
+msgstr ""
+"Candidatos que también se presentaron en %(prior_election_name)s por el "
+"mismo partido:"
 
 #: cached_counts/templates/reports.html:48
 #, python-format
 msgid ""
 "Candidates standing again from the %(prior_election_name)s for a different "
 "party:"
-msgstr "Candidatos que se habían presentado en %(prior_election_name)s por un partido diferente:"
+msgstr ""
+"Candidatos que se habían presentado en %(prior_election_name)s por un "
+"partido diferente:"
 
 #: cached_counts/templates/reports.html:60
 msgid "No election data found."
@@ -135,8 +143,7 @@ msgstr ""
 
 #: candidates/diffs.py:38
 #, python-brace-format
-msgid ""
-"is known to be standing for the party with ID {party} in the {election}"
+msgid "is known to be standing for the party with ID {party} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:40
@@ -177,8 +184,7 @@ msgstr ""
 
 #: candidates/diffs.py:66
 #, python-brace-format
-msgid ""
-"was known to be standing for the post with ID {party} in the {election}"
+msgid "was known to be standing for the post with ID {party} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:70
@@ -310,14 +316,18 @@ msgstr "Página del candidato en el sitio del partido"
 msgid ""
 "The Twitter username must only consist of alphanumeric characters or "
 "underscore"
-msgstr "El usuario de twitter sólo debe contener caracteres alfanuméricos o guión abajo "
+msgstr ""
+"El usuario de twitter sólo debe contener caracteres alfanuméricos o guión "
+"abajo "
 
 #: candidates/forms.py:156
 #, python-brace-format
 msgid ""
 "If you mark the candidate as standing in the {election}, you must select a "
 "constituency"
-msgstr "Si marcas un candidato como que se presenta en {election}, debes seleccionar un distrito"
+msgstr ""
+"Si marcas un candidato como que se presenta en {election}, debes seleccionar "
+"un distrito"
 
 #: candidates/forms.py:164
 #, python-brace-format
@@ -378,7 +388,9 @@ msgstr "Fuente de información para este cambio ({0})"
 msgid ""
 "You can only edit data on YourNextMP if you agree to this copyright "
 "assignment."
-msgstr "Sólo podrás editar datos en YoQuieroSaber Investigación si aceptas estos términos."
+msgstr ""
+"Sólo podrás editar datos en YoQuieroSaber Investigación si aceptas estos "
+"términos."
 
 #: candidates/forms.py:350
 #, python-brace-format
@@ -397,7 +409,9 @@ msgstr "Disculpas, pero hay caracteres no permitidos en \"{0}\""
 #: candidates/mapit.py:42
 #, python-brace-format
 msgid "No constituency found for the postcode \"{0}\""
-msgstr "Disculpas, no se encontró el distrito correspondiente al código postal \"{0}\""
+msgstr ""
+"Disculpas, no se encontró el distrito correspondiente al código postal "
+"\"{0}\""
 
 #: candidates/mapit.py:53
 #, python-brace-format
@@ -407,7 +421,9 @@ msgstr "Disculpas, el código postal \"{0}\" no pudo ser encontrado"
 #: candidates/mapit.py:57
 #, python-brace-format
 msgid "Unknown MapIt error for postcode \"{0}\""
-msgstr "Disculpas, ocurrió un error desconocido de MapIt para el código postal \"{0}\""
+msgstr ""
+"Disculpas, ocurrió un error desconocido de MapIt para el código postal "
+"\"{0}\""
 
 #: candidates/middleware.py:42
 #, python-brace-format
@@ -417,7 +433,12 @@ msgid ""
 "  {0}\n"
 "\n"
 "If this update is appropriate, someone should apply it manually.\n"
-msgstr "Como precaución, esta actualización fue bloqueada:\n\n{0}\n\nSi esta actualización es apropiada, alguien debería aplicarla manualmente.\n"
+msgstr ""
+"Como precaución, esta actualización fue bloqueada:\n"
+"\n"
+"{0}\n"
+"\n"
+"Si esta actualización es apropiada, alguien debería aplicarla manualmente.\n"
 
 #: candidates/middleware.py:49
 msgid "Disallowed YourNextMP update for checking"
@@ -431,7 +452,9 @@ msgstr "Disculpas, no se pudo encontrar la ubicación para '{0}'"
 #: candidates/models/address.py:39
 #, python-brace-format
 msgid "The address '{0}' appears to be outside the area this site knows about"
-msgstr "Disculpas, la dirección '{0}' parece estar fuera del área que este sitio conoce."
+msgstr ""
+"Disculpas, la dirección '{0}' parece estar fuera del área que este sitio "
+"conoce."
 
 #: candidates/models/auth.py:59
 msgid "The candidates for this post are locked now"
@@ -451,153 +474,169 @@ msgstr ""
 #: candidates/models/db.py:29
 #, python-brace-format
 msgid "given max_id is lower than the previous one ({0} vs {1})"
-msgstr "El max_id (identicador máximo) ingresado es menor que el anterior ({0} vs {1})"
+msgstr ""
+"El max_id (identicador máximo) ingresado es menor que el anterior ({0} vs "
+"{1})"
 
-#: candidates/models/popit.py:157
+#: candidates/models/popit.py:158
 #, python-brace-format
 msgid "Couldn't parse '{0}' as an ApproximateDate"
 msgstr "No se pudo procesar '{0}' como una fecha aproximada"
 
-#: candidates/models/popit.py:194
+#: candidates/models/popit.py:195
 #, python-brace-format
 msgid "Unknown partial ISO 8601 data format: {0}"
 msgstr "Disculpas, ocurrió un error. Unknown partial ISO 8601 data format: {0}"
 
-#: candidates/models/popit.py:283
+#: candidates/models/popit.py:281
 #, python-brace-format
 msgid "Failed to parse the MapIt URL: {0}"
 msgstr "Disculpas, ocurrió un error. Failed to parse the MapIt URL: {0}"
 
-#: candidates/models/popit.py:533
+#: candidates/models/popit.py:531
 #, python-brace-format
 msgid "'PopItPerson' has no attribute '{0}'"
 msgstr "Disculpas, ocurrió un error. 'PopItPerson' has no attribute '{0}'"
 
-#: candidates/models/popit.py:586
+#: candidates/models/popit.py:584
 msgid "There was no previous version of this person"
 msgstr "No hay versión anterior de la información de este candidato."
 
-#: candidates/models/popit.py:771
-#, python-brace-format
-msgid "Malformed parlparse ID found {0}"
-msgstr "Disculpas, ocurrió un error. Malformed parlparse ID found {0}"
-
-#: candidates/models/popit.py:1191
-msgid "Can't set_elected of a candidate with no standing_in"
-msgstr "Disculpas, ocurrió un error. Can't set_elected of a candidate with no standing_in"
-
 #: candidates/models/popit.py:1194
+msgid "Can't set_elected of a candidate with no standing_in"
+msgstr ""
+"Disculpas, ocurrió un error. Can't set_elected of a candidate with no "
+"standing_in"
+
+#: candidates/models/popit.py:1197
 #, python-brace-format
 msgid "No standing_in information for {0}"
-msgstr "Disculpas, ocurrió un error.  No hay información de que se presente a cargos para {0}. No standing_in information for {0}"
+msgstr ""
+"Disculpas, ocurrió un error.  No hay información de que se presente a cargos "
+"para {0}. No standing_in information for {0}"
 
 #: candidates/static_data.py:179
 #, python-brace-format
 msgid "Found multiple areas for the post ID {post_id}"
 msgstr ""
 
-#: candidates/templates/candidates/_candidates_for_post.html:64
+#: candidates/templates/candidates/_candidates_for_post.html:65
 msgid "(This list of candidates is currently <strong>locked</strong>.)"
 msgstr "(Esta lista de candidatos está <strong>cerrada</strong>.)"
 
-#: candidates/templates/candidates/_candidates_for_post.html:66
+#: candidates/templates/candidates/_candidates_for_post.html:67
 msgid "(This list of candidates is currently <strong>unlocked</strong>.)"
 msgstr "(Esta lista de candidatos está <strong>abierta</strong>.)"
 
-#: candidates/templates/candidates/_candidates_for_post.html:71
+#: candidates/templates/candidates/_candidates_for_post.html:72
 msgid ""
-"This list of candidates is now <strong>locked</strong>; you can still update"
-" contact details of candidates, but can't change the people standing in this"
-" constituency."
-msgstr "Esta lista de candidatos está <strong>cerrada</strong>; aún se puede actualizar información de contacto de los candidatos, pero no se puede cambiar la gente que se presenta en este distrito."
+"This list of candidates is now <strong>locked</strong>; you can still update "
+"contact details of candidates, but can't change the people standing in this "
+"constituency."
+msgstr ""
+"Esta lista de candidatos está <strong>cerrada</strong>; aún se puede "
+"actualizar información de contacto de los candidatos, pero no se puede "
+"cambiar la gente que se presenta en este distrito."
 
-#: candidates/templates/candidates/_candidates_for_post.html:80
+#: candidates/templates/candidates/_candidates_for_post.html:81
 msgid "Unset the current winner, if incorrect"
 msgstr "Quitar el ganador actual, si es incorrecto"
 
-#: candidates/templates/candidates/_candidates_for_post.html:88
+#: candidates/templates/candidates/_candidates_for_post.html:89
 #, python-format
 msgid "Known candidates for <a href=\"%(post_url)s\">%(post_label)s</a>"
 msgstr "Candidatos conocidos a <a href=\"%(post_url)s\">%(post_label)s</a>"
 
-#: candidates/templates/candidates/_candidates_for_post.html:98
+#: candidates/templates/candidates/_candidates_for_post.html:99
 msgid "Winner"
 msgstr "Ganador"
 
-#: candidates/templates/candidates/_candidates_for_post.html:105
+#: candidates/templates/candidates/_candidates_for_post.html:106
 msgid "Not actually standing?"
 msgstr "No se presenta?"
 
-#: candidates/templates/candidates/_candidates_for_post.html:107
-#: candidates/templates/candidates/_candidates_for_post.html:183
-#: candidates/templates/candidates/_candidates_for_post.html:211
+#: candidates/templates/candidates/_candidates_for_post.html:108
+#: candidates/templates/candidates/_candidates_for_post.html:188
+#: candidates/templates/candidates/_candidates_for_post.html:216
 msgid "Edit"
 msgstr "Modificar"
 
-#: candidates/templates/candidates/_candidates_for_post.html:117
+#: candidates/templates/candidates/_candidates_for_post.html:118
 msgid "[Quick update from the constituency page]"
 msgstr "[Actualización rápida desde la página del distrito]"
 
-#: candidates/templates/candidates/_candidates_for_post.html:118
+#: candidates/templates/candidates/_candidates_for_post.html:119
 msgid "This candidate won!"
 msgstr "¡Este candidato ganó!"
 
-#: candidates/templates/candidates/_candidates_for_post.html:128
+#: candidates/templates/candidates/_candidates_for_post.html:129
 #, python-format
 msgid ""
 "<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s "
 "for the %(election_name)s yet."
-msgstr "<strong>¡Epa!</strong> Aún no conocemos a ningún candidato a %(post_label)s para %(election_name)s."
+msgstr ""
+"<strong>¡Epa!</strong> Aún no conocemos a ningún candidato a %(post_label)s "
+"para %(election_name)s."
 
-#: candidates/templates/candidates/_candidates_for_post.html:131
-#: candidates/templates/candidates/_candidates_for_post.html:136
-#: candidates/templates/candidates/_candidates_for_post.html:144
+#: candidates/templates/candidates/_candidates_for_post.html:133
+#: candidates/templates/candidates/_candidates_for_post.html:141
+#: candidates/templates/candidates/_candidates_for_post.html:149
 #: candidates/templates/candidates/person-create.html:7
 msgid "Add a new candidate"
 msgstr "Agregar un candidato nuevo"
 
-#: candidates/templates/candidates/_candidates_for_post.html:155
+#: candidates/templates/candidates/_candidates_for_post.html:135
+#, fuzzy
+#| msgid "Add a new candidate"
+msgid "Sign in to add a new candidate"
+msgstr "Agregar un candidato nuevo"
+
+#: candidates/templates/candidates/_candidates_for_post.html:160
 msgid "Add new candidate"
 msgstr "Agregar candidato nuevo"
 
-#: candidates/templates/candidates/_candidates_for_post.html:156
+#: candidates/templates/candidates/_candidates_for_post.html:161
 #: candidates/templates/candidates/record-winner.html:35
 #: moderation_queue/templates/moderation_queue/photo-review.html:158
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: candidates/templates/candidates/_candidates_for_post.html:168
+#: candidates/templates/candidates/_candidates_for_post.html:173
 msgid "Is a candidate from the 2010 election standing again?"
 msgstr "¿Un candidato de la elección anterior se presenta de nuevo?"
 
-#: candidates/templates/candidates/_candidates_for_post.html:170
+#: candidates/templates/candidates/_candidates_for_post.html:175
 msgid ""
 "We don't know if these candidates from earlier elections are standing again"
-msgstr "No sabemos si estos candidatos de elecciones anteriores se presentan de nuevo"
+msgstr ""
+"No sabemos si estos candidatos de elecciones anteriores se presentan de nuevo"
 
-#: candidates/templates/candidates/_candidates_for_post.html:180
+#: candidates/templates/candidates/_candidates_for_post.html:185
 msgid "Standing again"
 msgstr "Se presenta de nuevo"
 
-#: candidates/templates/candidates/_candidates_for_post.html:181
+#: candidates/templates/candidates/_candidates_for_post.html:186
 msgid "Not standing again"
 msgstr "No se presenta de nuevo"
 
-#: candidates/templates/candidates/_candidates_for_post.html:200
+#: candidates/templates/candidates/_candidates_for_post.html:205
 msgid ""
 "These candidates from earlier elections are known not to be standing again"
 msgstr "Estos candidatos de elecciones anteriores no se presentan de nuevo"
 
-#: candidates/templates/candidates/_candidates_for_post.html:209
+#: candidates/templates/candidates/_candidates_for_post.html:214
 msgid "Actually, they are standing!"
 msgstr "¡De verdad, se presentan!"
 
 #: candidates/templates/candidates/_edits_disallowed_message.html:2
 #, python-format
 msgid ""
-"Editing of data in YourNextMP is now disabled, but if you have a correction,"
-" please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
-msgstr "Editar datos en YoQuieroSaber Investigación está deshabilitado, pero si tenés alguna corrección, por favor escríbinos a <a href=\"mailto:%(email)s\">%(email)s</a>"
+"Editing of data in YourNextMP is now disabled, but if you have a correction, "
+"please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
+msgstr ""
+"Editar datos en YoQuieroSaber Investigación está deshabilitado, pero si "
+"tenés alguna corrección, por favor escríbinos a <a href=\"mailto:%(email)s\">"
+"%(email)s</a>"
 
 #: candidates/templates/candidates/_photo-credit.html:8
 #, python-format
@@ -617,7 +656,9 @@ msgstr "El usuario comentó: “%(user_comment)s”."
 msgid ""
 "The volunteer moderator who reviewed this photo picked a different "
 "justification for its use on the site, which was:"
-msgstr "El moderador voluntario que revisó esta foto dió una justificación diferente para usarla en este sitio, que fué:"
+msgstr ""
+"El moderador voluntario que revisó esta foto dió una justificación diferente "
+"para usarla en este sitio, que fué:"
 
 #: candidates/templates/candidates/_photo-credit.html:27
 #, python-format
@@ -633,19 +674,26 @@ msgstr "Notas sobre esta imágen: “%(notes)s”."
 msgid ""
 "the photo is free of copyright restrictions (i.e. has explictly been placed "
 "in the public domain)"
-msgstr "la foto está libre de restricciones de copyright (por ejemplo, fué puesta explícitamente en el dominio público, o está publicada con licencia Creative Commons)"
+msgstr ""
+"la foto está libre de restricciones de copyright (por ejemplo, fué puesta "
+"explícitamente en el dominio público, o está publicada con licencia Creative "
+"Commons)"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:8
 msgid ""
 "they have assigned the copyright of the image to Democracy Club so that we "
 "may use it on the site"
-msgstr "Han asignado el copyright de la imágen a YoQuieroSaber para que lo podamos usar en el sitio"
+msgstr ""
+"Han asignado el copyright de la imágen a YoQuieroSaber para que lo podamos "
+"usar en el sitio"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:13
 msgid ""
-"this photo is the candidate's profile on social media, or is used to promote"
-" their candidacy on an official candidate or party website"
-msgstr "la foto es el perfil del candidato en medios sociales, o es usada para promover su candidatura en un sitio oficial del candidato o del partido"
+"this photo is the candidate's profile on social media, or is used to promote "
+"their candidacy on an official candidate or party website"
+msgstr ""
+"la foto es el perfil del candidato en medios sociales, o es usada para "
+"promover su candidatura en un sitio oficial del candidato o del partido"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:18
 msgid "there is some reasonable justification for its use"
@@ -673,42 +721,64 @@ msgstr "Acerca de este sitio"
 #: candidates/templates/candidates/about.html:17
 #, python-format
 msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or"
-" bug reports. If you'd like to discuss this site or any other project "
-"relating to elections in the UK, we'd suggest that you post to the <a "
-"href=\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy "
-"Club Google Group</a>."
-msgstr "Por favor envíe un correo a <a href=\"mailto:%(email)s\">%(email)s</a> con cualquier devolución o reporte de errores. \nPara debatir sobre este sitio u otros proyectos relacionados a las elecciones argentinas, puede participar en nuestra <a href=\"https://groups.google.com/forum/#!forum/yoquierosaber2015\">lista de correo</a."
+"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or "
+"bug reports. If you'd like to discuss this site or any other project "
+"relating to elections in the UK, we'd suggest that you post to the <a href="
+"\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy Club "
+"Google Group</a>."
+msgstr ""
+"Por favor envíe un correo a <a href=\"mailto:%(email)s\">%(email)s</a> con "
+"cualquier devolución o reporte de errores. \n"
+"Para debatir sobre este sitio u otros proyectos relacionados a las "
+"elecciones argentinas, puede participar en nuestra <a href=\"https://groups."
+"google.com/forum/#!forum/yoquierosaber2015\">lista de correo</a."
 
 #: candidates/templates/candidates/about.html:26
 msgid ""
-"The source code for this site is <a href=\"https://github.com/mysociety"
-"/yournextmp-popit/\">available on GitHub</a>, and you can find a <a "
-"href=\"https://github.com/mysociety/yournextmp-popit/issues\">list of known "
-"bugs</a> there as well."
-msgstr "El código fuente de este sitio está <a href=\"https://github.com/mysociety/yournextmp-popit/\">disponible en GitHub</a>, y podés encontrar la <a href=\"https://github.com/mysociety/yournextmp-popit/issues\">lista de errores conocidos</a> ahí también.\nY este es nuestro <a href=\"https://github.com/YoQuieroSaber/yournextmp-popit/\">fork para Argentina</a>, en GitHub también."
+"The source code for this site is <a href=\"https://github.com/mysociety/"
+"yournextmp-popit/\">available on GitHub</a>, and you can find a <a href="
+"\"https://github.com/mysociety/yournextmp-popit/issues\">list of known bugs</"
+"a> there as well."
+msgstr ""
+"El código fuente de este sitio está <a href=\"https://github.com/mysociety/"
+"yournextmp-popit/\">disponible en GitHub</a>, y podés encontrar la <a href="
+"\"https://github.com/mysociety/yournextmp-popit/issues\">lista de errores "
+"conocidos</a> ahí también.\n"
+"Y este es nuestro <a href=\"https://github.com/YoQuieroSaber/yournextmp-"
+"popit/\">fork para Argentina</a>, en GitHub también."
 
 #: candidates/templates/candidates/about.html:34
 msgid ""
 "This site was developed by Mark Longair (mySociety), Sym Roe (Democracy "
 "Club) and Zarino Zappia (mySociety)."
-msgstr "This site was developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety).\nEste sitio fué desarrollado por Martín Szyszlican (Congreso Interacitivo) y los colaboradres del proyecto YoQuieroSaber."
+msgstr ""
+"This site was developed by Mark Longair (mySociety), Sym Roe (Democracy "
+"Club) and Zarino Zappia (mySociety).\n"
+"Este sitio fué desarrollado por Martín Szyszlican (Congreso Interacitivo) y "
+"los colaboradres del proyecto YoQuieroSaber."
 
 #: candidates/templates/candidates/about.html:39
 msgid ""
 "The data on candidates from the last UK general election in 2010 is all "
-"taken from Edmund von der Burg's <a "
-"href=\"http://www.yournextmp.com\">YourNextMP.com</a>, with many thanks."
-msgstr "Los datos de los candidatos de las últimas elecciones de 2011 fueron tomados de YoQuieroSaber 2011"
+"taken from Edmund von der Burg's <a href=\"http://www.yournextmp.com"
+"\">YourNextMP.com</a>, with many thanks."
+msgstr ""
+"Los datos de los candidatos de las últimas elecciones de 2011 fueron tomados "
+"de YoQuieroSaber 2011"
 
 #: candidates/templates/candidates/about.html:47
 #, python-format
 msgid ""
 "You can use the data from this site, via the <a href=\"%(api_url)s\">API or "
-"CSV download</a>, under the terms of the Creative Commons license <a "
-"href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-"
-"ShareAlike (CC-BY-SA)</a> with the exception of:"
-msgstr "Podés usar los datos de este sitio, a través de la <a href=\"%(api_url)s\">API o descarga CSV</a>, bajo los términos de la licencia Creative Commons <a href=\"https://creativecommons.org/licenses/by-sa/4.0/deed.es\">Atribución-CompartirIgual 4.0 Internacional (CC BY-SA 4.0)/a> con la excepción de:"
+"CSV download</a>, under the terms of the Creative Commons license <a href="
+"\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-ShareAlike "
+"(CC-BY-SA)</a> with the exception of:"
+msgstr ""
+"Podés usar los datos de este sitio, a través de la <a href=\"%(api_url)s"
+"\">API o descarga CSV</a>, bajo los términos de la licencia Creative Commons "
+"<a href=\"https://creativecommons.org/licenses/by-sa/4.0/deed.es"
+"\">Atribución-CompartirIgual 4.0 Internacional (CC BY-SA 4.0)/a> con la "
+"excepción de:"
 
 #: candidates/templates/candidates/about.html:56
 msgid ""
@@ -718,25 +788,30 @@ msgstr "Los logos de los partidos."
 #: candidates/templates/candidates/about.html:57
 msgid ""
 "Candidate photos, which are typically either submitted by the candidates "
-"themselves, or from sources where it seems reasonable that we might use them"
-" on this site, such as the party's official page for that candidate, or "
-"their social media profile picture."
-msgstr "Las fotos de los candidatos, que típicamente son enviadas por los propios candidaos, o de fuentes donde parece razonable que podaos usarlas, como la página oficial del candidato o su perfil en medios sociales."
+"themselves, or from sources where it seems reasonable that we might use them "
+"on this site, such as the party's official page for that candidate, or their "
+"social media profile picture."
+msgstr ""
+"Las fotos de los candidatos, que típicamente son enviadas por los propios "
+"candidaos, o de fuentes donde parece razonable que podaos usarlas, como la "
+"página oficial del candidato o su perfil en medios sociales."
 
 #: candidates/templates/candidates/about.html:65
 #, python-format
 msgid ""
-"If the CC-BY-SA licence is problematic for you, but you feel that you have a"
-" worthwhile use of the data in mind, please <a "
-"href=\"mailto:%(email)s\">contact us</a> to discuss your situation further."
-msgstr "Si la licencia CC-BY-SA le resulta problemática, por favor <a href=\"mailto:%(email)s\">contáctenos</a> para charlar sobre su situacion."
+"If the CC-BY-SA licence is problematic for you, but you feel that you have a "
+"worthwhile use of the data in mind, please <a href=\"mailto:%(email)s"
+"\">contact us</a> to discuss your situation further."
+msgstr ""
+"Si la licencia CC-BY-SA le resulta problemática, por favor <a href=\"mailto:"
+"%(email)s\">contáctenos</a> para charlar sobre su situacion."
 
 #: candidates/templates/candidates/about.html:71
 #, python-format
 msgid ""
-"For complicated reasons relating to database licensing, we have put the data"
-" as of the 4th of March 2015 into the public domain by declaring it to be <a"
-" href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This "
+"For complicated reasons relating to database licensing, we have put the data "
+"as of the 4th of March 2015 into the public domain by declaring it to be <a "
+"href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This "
 "data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-"
 "date/\">here</a> but please be warned that this snapshot will become "
 "inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date "
@@ -749,8 +824,11 @@ msgstr "Política de privacidad"
 
 #: candidates/templates/candidates/about.html:86
 #, python-format
-msgid "The privacy policy of this site can be found <a href=\"%(url)s\">here</a>."
-msgstr "La política de privacidad de este sitio  <a href=\"%(url)s\">puede ser encontrada aquí</a>."
+msgid ""
+"The privacy policy of this site can be found <a href=\"%(url)s\">here</a>."
+msgstr ""
+"La política de privacidad de este sitio  <a href=\"%(url)s\">puede ser "
+"encontrada aquí</a>."
 
 #: candidates/templates/candidates/about.html:91
 msgid "Disclaimer"
@@ -761,9 +839,12 @@ msgstr "Descargo de responsabilidades"
 msgid ""
 "The data on this website is crowd-sourced and may not be complete (or may "
 "contain inaccuracies). If you find an error, please either update the page "
-"yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the "
-"problem."
-msgstr "La información en este sitio es producto de una investigación colectiva (crowd-source) y puede no estar completa o contener inexactitudes. Si encuentra un error, por favor actualice la página usted mismo, o <a href=\"mailto:%(email)s\">envíenos un correo</a> para reportar el problema."
+"yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the problem."
+msgstr ""
+"La información en este sitio es producto de una investigación colectiva "
+"(crowd-source) y puede no estar completa o contener inexactitudes. Si "
+"encuentra un error, por favor actualice la página usted mismo, o <a href="
+"\"mailto:%(email)s\">envíenos un correo</a> para reportar el problema."
 
 #: candidates/templates/candidates/all-edits-disallowed.html:6
 #: candidates/templates/candidates/all-edits-disallowed.html:9
@@ -788,7 +869,12 @@ msgid ""
 "and programmatically via a RESTful web service called PopIt, which stores "
 "information about people and their positions in organizations. (You can <a "
 "href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
-msgstr "Los datos enviados a este sitio están disponibles como un archivo CSV (formato Excel) para descargar y para su acceso automatizado metiante una API RESTful, de un webservice llamado PopIt, que almacena información sobre personas y sus posiciones en organizaciones. Podés  <a href=\"http://popit.poplus.org/\">saber más sobre PopIt en su sitio web</a>."
+msgstr ""
+"Los datos enviados a este sitio están disponibles como un archivo CSV "
+"(formato Excel) para descargar y para su acceso automatizado metiante una "
+"API RESTful, de un webservice llamado PopIt, que almacena información sobre "
+"personas y sus posiciones en organizaciones. Podés  <a href=\"http://popit."
+"poplus.org/\">saber más sobre PopIt en su sitio web</a>."
 
 #: candidates/templates/candidates/api.html:24
 msgid "CSV/Excel Download"
@@ -811,7 +897,10 @@ msgid ""
 "You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic "
 "documentation for the PopIt API</a> or just follow the simple examples that "
 "follow."
-msgstr "Podés leer <a href=\"http://popit.poplus.org/docs/api/\">documentación más genérica para la API de PopIt</a> o seguir los simples ejemplos a continuación."
+msgstr ""
+"Podés leer <a href=\"http://popit.poplus.org/docs/api/\">documentación más "
+"genérica para la API de PopIt</a> o seguir los simples ejemplos a "
+"continuación."
 
 #: candidates/templates/candidates/api.html:42
 msgid "Find a Constituency ID"
@@ -820,9 +909,9 @@ msgstr "Encontrar el ID de un distrito"
 #: candidates/templates/candidates/api.html:44
 msgid ""
 "In order to look up candidates for a constituency, you have to find the ID "
-"of that constituency. The IDs that we use for constituencies are the IDs for"
-" Westminster constituencies areas in another web service, <a "
-"href=\"http://mapit.mysociety.org\">MapIt</a>."
+"of that constituency. The IDs that we use for constituencies are the IDs for "
+"Westminster constituencies areas in another web service, <a href=\"http://"
+"mapit.mysociety.org\">MapIt</a>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:52
@@ -838,14 +927,14 @@ msgstr ""
 #: candidates/templates/candidates/api.html:64
 msgid ""
 "This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON "
-"object</a>, wherein the constituency ID can be found at "
-"<tt>.shortcuts.WMC</tt>."
+"object</a>, wherein the constituency ID can be found at <tt>.shortcuts.WMC</"
+"tt>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:70
 msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org"
-"/#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
+"There's more documentation available on <a href=\"http://mapit.mysociety.org/"
+"#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:76
@@ -857,8 +946,8 @@ msgid ""
 "You can look up constituencies in MapIt using a variety of coordinate "
 "systems. To give the most common example, you might have a WGS84 coordinate "
 "from a GPS or location API, in which can you should put the SRID 4326 in "
-"your lookup. For example, latitude 52.205083 and longitude 0.115194 could be"
-" looked up with:"
+"your lookup. For example, latitude 52.205083 and longitude 0.115194 could be "
+"looked up with:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:90
@@ -869,8 +958,8 @@ msgstr ""
 
 #: candidates/templates/candidates/api.html:96
 msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org"
-"/#api-by_point\">point lookups on the MapIt front-page</a>."
+"There's more documentation available on <a href=\"http://mapit.mysociety.org/"
+"#api-by_point\">point lookups on the MapIt front-page</a>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:102
@@ -886,10 +975,10 @@ msgstr ""
 
 #: candidates/templates/candidates/api.html:114
 msgid ""
-"The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that"
-" request</a> has the constituency ID as its keys; the values are objects "
-"that include (among other things) a <tt>name</tt> element that gives you the"
-" official name of the constituency."
+"The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that "
+"request</a> has the constituency ID as its keys; the values are objects that "
+"include (among other things) a <tt>name</tt> element that gives you the "
+"official name of the constituency."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:122
@@ -900,8 +989,8 @@ msgstr "Encontrar candidatos para un distrito electoral"
 msgid ""
 "There are broadly two ways you can approach getting candidate data for a "
 "constituency; one is slightly simpler, and just gives you the basic "
-"candidate and party information, while the second gives you the full data in"
-" Popolo format, which is more complex but useful if you're using tools that "
+"candidate and party information, while the second gives you the full data in "
+"Popolo format, which is more complex but useful if you're using tools that "
 "generically process Popolo data."
 msgstr ""
 
@@ -918,9 +1007,9 @@ msgstr ""
 #: candidates/templates/candidates/api.html:144
 #, python-format
 msgid ""
-"For example, for Dulwich and West Norwood, <a "
-"href=\"%(popit_url)sposts/65808?embed=membership.person\">these would be the"
-" results</a>."
+"For example, for Dulwich and West Norwood, <a href="
+"\"%(popit_url)sposts/65808?embed=membership.person\">these would be the "
+"results</a>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:150
@@ -931,8 +1020,8 @@ msgstr ""
 
 #: candidates/templates/candidates/api.html:178
 msgid ""
-"(I've removed some fields there to keep the example simpler.) The two fields"
-" of particular interest are probably <tt>standing_in</tt> and "
+"(I've removed some fields there to keep the example simpler.) The two fields "
+"of particular interest are probably <tt>standing_in</tt> and "
 "<tt>party_memberships</tt>."
 msgstr ""
 
@@ -952,8 +1041,8 @@ msgstr ""
 msgid ""
 "This object will similarly only have keys '2010' or '2015' and tells you "
 "what party the candidate is / was standing for in the general election of "
-"that year.  So in the example above, you can see that Tessa Jowell stood for"
-" the Labour Party in 2010, but has no entry for 2015 (because, as the "
+"that year.  So in the example above, you can see that Tessa Jowell stood for "
+"the Labour Party in 2010, but has no entry for 2015 (because, as the "
 "<tt>standing_in</tt> tells us) she's not standing in 2015."
 msgstr ""
 
@@ -971,13 +1060,13 @@ msgstr ""
 #: candidates/templates/candidates/api.html:222
 #, python-format
 msgid ""
-"For example, for Dulwich and West Norwood, <a "
-"href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">these"
-" would be the results</a>. To explain further, that's showing information "
-"about the <em>post</em> \"MP for Dulwich and West Norwood\". Under the "
-"<tt>memberships</tt> key of the <tt>result</tt> dictionary you can find all "
-"memberships of this post - those that have the <tt>role</tt> \"Candidate\" "
-"were candidates at one point."
+"For example, for Dulwich and West Norwood, <a href="
+"\"%(popit_url)sposts/65808?embed=membership.person.membership.organization"
+"\">these would be the results</a>. To explain further, that's showing "
+"information about the <em>post</em> \"MP for Dulwich and West Norwood\". "
+"Under the <tt>memberships</tt> key of the <tt>result</tt> dictionary you can "
+"find all memberships of this post - those that have the <tt>role</tt> "
+"\"Candidate\" were candidates at one point."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:232
@@ -992,8 +1081,8 @@ msgid ""
 "Under <tt>person_id</tt> attribute of each of those membership you can find "
 "information about that candidate, like their name, contact details and (in "
 "another nested <tt>memberships</tt> object) their memberships of political "
-"parties. The party memberships use the same date values as above to indicate"
-" whether it's their party membership at the 2010 or 2015 election."
+"parties. The party memberships use the same date values as above to indicate "
+"whether it's their party membership at the 2010 or 2015 election."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:257
@@ -1009,10 +1098,10 @@ msgstr ""
 #: candidates/templates/candidates/api.html:268
 #, python-format
 msgid ""
-"For example, you can find every David Jones in the database with <a "
-"href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this "
-"query</a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt>"
-" elements will give you details about which constituencies they are / were "
+"For example, you can find every David Jones in the database with <a href="
+"\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this query</"
+"a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt> "
+"elements will give you details about which constituencies they are / were "
 "standing in, and for which parties."
 msgstr ""
 
@@ -1024,9 +1113,9 @@ msgstr "Conozca a los pre-candidatos de las PASO 2015"
 #, python-format
 msgid ""
 "You can also use the <tt>search/persons</tt> endpoint to find all the "
-"candidates that we think are standing in 2015, with <a "
-"href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id "
-"\">this query</a>:"
+"candidates that we think are standing in 2015, with <a href="
+"\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id \">this "
+"query</a>:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:290
@@ -1053,10 +1142,10 @@ msgid ""
 "Before you carry on to edit data in YourNextMP, we need you to agree that "
 "your contributions to this site (with the exception of photo uploads) are "
 "owned by Democracy Club Limited. In return, we agree to make the complete "
-"database available under an open licence such as <a "
-"href=\"http://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or "
-"remove copyright restrictions by releasing into the public domain (<a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
+"database available under an open licence such as <a href=\"http://"
+"creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or remove copyright "
+"restrictions by releasing into the public domain (<a href=\"https://"
+"creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
 msgstr "FALTA EL TEXTO DEL ACUERDO"
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:33
@@ -1072,10 +1161,13 @@ msgstr "Continuar"
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:42
 #, python-format
 msgid ""
-"Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a "
-"href=\"mailto:%(email)s\">email us</a> if you have any questions about this "
+"Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a href="
+"\"mailto:%(email)s\">email us</a> if you have any questions about this "
 "agreement."
-msgstr "De lo contrario puede <a href=\"%(url)s\">cerrar sesión</a>. Por favor <a href=\"mailto:%(email)s\">escríbanos</a> si tiene preguntas sobre este acuerdo."
+msgstr ""
+"De lo contrario puede <a href=\"%(url)s\">cerrar sesión</a>. Por favor <a "
+"href=\"mailto:%(email)s\">escríbanos</a> si tiene preguntas sobre este "
+"acuerdo."
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:50
 msgid "Why are we asking you to agree to this?"
@@ -1083,15 +1175,15 @@ msgstr "¿Por qué le pedimos que acepte esto?"
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:52
 msgid ""
-"When we originally set up YourNextMP for the 2015 general election we didn't"
-" get legal advice about the best way to deal with copyright and licensing. "
-"It turns out that the way that the user agreement that was worded on the "
+"When we originally set up YourNextMP for the 2015 general election we didn't "
+"get legal advice about the best way to deal with copyright and licensing. It "
+"turns out that the way that the user agreement that was worded on the "
 "'About' page had a few problems, and in particular restricted what we could "
-"do with the data such that we couldn't license the database to some partners"
-" who we thought would make good use of the data but who needed slightly "
-"different licensing. The simplest way to ensure that we can make the data as"
-" widely available as possible while preventing the hard work of contributors"
-" to YourNextMP being co-opted by companies building closed candidate "
+"do with the data such that we couldn't license the database to some partners "
+"who we thought would make good use of the data but who needed slightly "
+"different licensing. The simplest way to ensure that we can make the data as "
+"widely available as possible while preventing the hard work of contributors "
+"to YourNextMP being co-opted by companies building closed candidate "
 "databases is to ask you to assign the copyright of your contributions to "
 "Democracy Club."
 msgstr "FALTA TEXTO"
@@ -1103,12 +1195,18 @@ msgid "How do you know that %(name)s is standing?"
 msgstr "¿Cómo sabes que %(name)s se presenta?"
 
 #: candidates/templates/candidates/candidacy-create.html:14
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "Before updating our records we need to know the source for your "
+#| "information that %(name)s is standing for election in the 2015 general "
+#| "election in %(constituency)s."
 msgid ""
 "Before updating our records we need to know the source for your information "
-"that %(name)s is standing for election in the 2015 general election in "
-"%(constituency)s."
-msgstr "Antes de actualizar nuestros registros, necesitamos la fuente de información de que %(name)s se presenta para las PASO 2015 en %(constituency)s."
+"that %(name)s is standing for election to the post of %(post_label)s in the "
+"%(election_name)s."
+msgstr ""
+"Antes de actualizar nuestros registros, necesitamos la fuente de información "
+"de que %(name)s se presenta para las PASO 2015 en %(constituency)s."
 
 #: candidates/templates/candidates/candidacy-delete.html:6
 #: candidates/templates/candidates/candidacy-delete.html:9
@@ -1117,11 +1215,18 @@ msgid "How do you know that %(name)s isn’t standing?"
 msgstr "Cómo sabés que %(name)s no se presenta?"
 
 #: candidates/templates/candidates/candidacy-delete.html:14
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "Before updating our records we need to know the source for your "
+#| "information that %(name)s is standing for election in the 2015 general "
+#| "election in %(constituency)s."
 msgid ""
-"your information that %(name)s <strong>isn’t</strong> standing for election "
-"in the 2015 general election in %(constituency)s."
-msgstr "tu información de que %(name)s <strong>no</strong> se presenta para las PASO 2015en %(constituency)s."
+"Before updating our records we need to know the source for your information "
+"that %(name)s <strong>isn’t</strong> standing for election to the post of "
+"%(post_label)s in the %(election_name)s."
+msgstr ""
+"Antes de actualizar nuestros registros, necesitamos la fuente de información "
+"de que %(name)s se presenta para las PASO 2015 en %(constituency)s."
 
 #: candidates/templates/candidates/constituencies-declared.html:6
 #: candidates/templates/candidates/constituencies-unlocked.html:6
@@ -1164,7 +1269,8 @@ msgstr "Todos los distritos para las PASO 2015"
 msgid ""
 "Follow one of the links below to see the known candidates for that "
 "constituency:"
-msgstr "Sigue uno de los enlaces abajo para ver los candidatos de ese distrito:"
+msgstr ""
+"Sigue uno de los enlaces abajo para ver los candidatos de ese distrito:"
 
 #: candidates/templates/candidates/constituency.html:9
 #: candidates/templates/candidates/constituency.html:32
@@ -1224,7 +1330,10 @@ msgid ""
 "As a staff user, you can invalidate any cached data for this constituency. "
 "This may <em>occasionally</em> be necessary if the page is showing stale "
 "information for more than 10 seconds."
-msgstr "Como moderador, podés invalidar los datos en cache (actualizar) para este distrito. Esto puede ocasionalmente ser necesario si la página muestra información vieja por más de 10 segundos."
+msgstr ""
+"Como moderador, podés invalidar los datos en cache (actualizar) para este "
+"distrito. Esto puede ocasionalmente ser necesario si la página muestra "
+"información vieja por más de 10 segundos."
 
 #: candidates/templates/candidates/frontpage.html:14
 #: candidates/templates/candidates/frontpage.html:25
@@ -1240,7 +1349,8 @@ msgstr "Encontrá candidatos"
 msgid ""
 "Don’t pay for a candidate database sold by a data vendor — it’s a waste of "
 "money."
-msgstr "No le pagues a un proveedor de bases de datos -- es un desperdicio de dinero."
+msgstr ""
+"No le pagues a un proveedor de bases de datos -- es un desperdicio de dinero."
 
 #: candidates/templates/candidates/frontpage.html:44
 msgid "Show candidates"
@@ -1248,7 +1358,8 @@ msgstr "Mostrar candidatos"
 
 #: candidates/templates/candidates/frontpage.html:53
 msgid "This is a crowd-sourced database of election candidates."
-msgstr "Esta base de datos de candidatos es producto de una investigación colectiva"
+msgstr ""
+"Esta base de datos de candidatos es producto de una investigación colectiva"
 
 #: candidates/templates/candidates/frontpage.html:57
 #, python-format
@@ -1257,7 +1368,11 @@ msgid ""
 "suitable for building other election websites. <a href=\"%(api_url)s\">Get "
 "the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new "
 "candidate details.</a>"
-msgstr "Esta base de datos tiene fuentes transparentes y está disponible como datos estructurados, lo que permite hacer otras aplicaciones con esta información. <a href=\"%(api_url)s\">Obtené los datos ahora</a>, o <a href=\"%(tasks_url)s\">colaborá con más detalles de los candidatos.</a>"
+msgstr ""
+"Esta base de datos tiene fuentes transparentes y está disponible como datos "
+"estructurados, lo que permite hacer otras aplicaciones con esta información. "
+"<a href=\"%(api_url)s\">Obtené los datos ahora</a>, o <a href=\"%(tasks_url)s"
+"\">colaborá con más detalles de los candidatos.</a>"
 
 #: candidates/templates/candidates/frontpage.html:70
 msgid "Recent changes"
@@ -1268,100 +1383,134 @@ msgstr "Cambios recientes"
 msgid ""
 "User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new "
 "candidate</a> <span class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> agregó <a href=\"%(person_url)s\">un nuevo candidato</a>, <span class=\"when\">hace %(when)s</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> agregó <a href=\"%(person_url)s"
+"\">un nuevo candidato</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:83
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> is creating a new candidate <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> está agregando un nuevo candidato, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> is creating a new candidate <span class="
+"\"when\">%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> está agregando un nuevo candidato, "
+"<span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:89
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> merged another candidate into <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> unificó otro candidato con <a href=\"%(person_url)s\">el candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> merged another candidate into <a href="
+"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
+"%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> unificó otro candidato con <a href="
+"\"%(person_url)s\">el candidato #%(person_id)s</a>, <span class=\"when"
+"\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:95
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> uploaded a photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> subió una foto de <a href=\"%(person_url)s\">el candidato #%(person_id)s</a> para ser moderada, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> uploaded a photo of <a href="
+"\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span class="
+"\"when\">%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> subió una foto de <a href="
+"\"%(person_url)s\">el candidato #%(person_id)s</a> para ser moderada, <span "
+"class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:101
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> approved an uploaded photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> aprobó una foto subida del <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> approved an uploaded photo of <a href="
+"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
+"%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> aprobó una foto subida del <a href="
+"\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace "
+"%(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:107
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> rejected an uploaded photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> rechazó una foto subida de <a href=\"%(person_url)s\">el candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> rejected an uploaded photo of <a href="
+"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
+"%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> rechazó una foto subida de <a href="
+"\"%(person_url)s\">el candidato #%(person_id)s</a>, <span class=\"when"
+"\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:113
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> reverted to an earlier version of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> volvió a una versión anterior del <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> reverted to an earlier version of <a href="
+"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
+"%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> volvió a una versión anterior del "
+"<a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when"
+"\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:119
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> confirmed candidacy for <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> confirmó la candidatura del <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> confirmed candidacy for <a href="
+"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
+"%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> confirmó la candidatura del <a href="
+"\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace "
+"%(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:125
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> removed candidacy for <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> eliminó la candidatura del <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> removed candidacy for <a href="
+"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
+"%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> eliminó la candidatura del <a href="
+"\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace "
+"%(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:131
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> locked a constituency <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> cerró un distrito, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> locked a constituency <span class=\"when"
+"\">%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> cerró un distrito, <span class="
+"\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:135
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> unlocked a constituency <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong>abrió un distrito, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> unlocked a constituency <span class=\"when"
+"\">%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong>abrió un distrito, <span class=\"when"
+"\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:139
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> marked <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> as the winner <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> declaró ganador al <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> marked <a href=\"%(person_url)s"
+"\">candidate #%(person_id)s</a> as the winner <span class=\"when\">%(when)s "
+"ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> declaró ganador al <a href="
+"\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace "
+"%(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:145
 #, python-format
 msgid ""
-"User <strong>%(username)s</strong> updated <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
-msgstr "El usuario <strong>%(username)s</strong> actualizó al <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
+"User <strong>%(username)s</strong> updated <a href=\"%(person_url)s"
+"\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
+msgstr ""
+"El usuario <strong>%(username)s</strong> actualizó al <a href="
+"\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace "
+"%(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:154
 msgid "Show more changes…"
@@ -1420,7 +1569,9 @@ msgstr "Candidatos del partido %(party_name)s a las PASO 2015"
 msgid ""
 "This shows all the constituencies that have independent candidates standing "
 "in them at the 2015 general election"
-msgstr "Muestra todos los distritos que tienen candidatos independientes para las PASO 2015"
+msgstr ""
+"Muestra todos los distritos que tienen candidatos independientes para las "
+"PASO 2015"
 
 #: candidates/templates/candidates/party.html:25
 msgid ""
@@ -1434,21 +1585,28 @@ msgstr ""
 #, python-format
 msgid ""
 "%(party_name)s is on the Electoral Commission's register for %(register)s."
-msgstr "%(party_name)s está en el registro de la Comisión Nacional Electoral para %(register)s."
+msgstr ""
+"%(party_name)s está en el registro de la Comisión Nacional Electoral para "
+"%(register)s."
 
 #: candidates/templates/candidates/party.html:35
 #, python-format
 msgid ""
-"You can find more data about the party's registration at the <a "
-"href=\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
-msgstr "Podés encontrar más información sobre la registración del partido en la <a href=\"%(ec_url)s\">página de la Comisión Nacional Electoral para %(party_name)s</a>."
+"You can find more data about the party's registration at the <a href="
+"\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
+msgstr ""
+"Podés encontrar más información sobre la registración del partido en la <a "
+"href=\"%(ec_url)s\">página de la Comisión Nacional Electoral para "
+"%(party_name)s</a>."
 
 #: candidates/templates/candidates/party.html:51
 #, python-format
 msgid ""
-"<a href=\"%(person_url)s\">%(name)s</a> is standing in <a "
-"href=\"%(post_url)s\">%(post)s</a>"
-msgstr "<a href=\"%(person_url)s\">%(name)s</a> se presenta para <a href=\"%(post_url)s\">%(post)s</a>"
+"<a href=\"%(person_url)s\">%(name)s</a> is standing in <a href=\"%(post_url)s"
+"\">%(post)s</a>"
+msgstr ""
+"<a href=\"%(person_url)s\">%(name)s</a> se presenta para <a href="
+"\"%(post_url)s\">%(post)s</a>"
 
 #: candidates/templates/candidates/party.html:55
 #, python-format
@@ -1472,7 +1630,8 @@ msgstr ""
 #: candidates/templates/candidates/party.html:75
 #, python-format
 msgid "We don't know of any %(party_name)s candidates in %(country)s so far."
-msgstr "No conocemos ningún candidato de %(party_name)s en %(country)s hasta ahora."
+msgstr ""
+"No conocemos ningún candidato de %(party_name)s en %(country)s hasta ahora."
 
 #: candidates/templates/candidates/person-edit.html:9
 #: candidates/templates/candidates/person-edit.html:20
@@ -1495,7 +1654,9 @@ msgstr "No pudimos aceptar algunos de los cambios que hiciste."
 
 #: candidates/templates/candidates/person-edit.html:46
 msgid "Please check your information matches our requirements, below."
-msgstr "Por favor verificá que tu información cumple con nuestros requerimientos, a continuación."
+msgstr ""
+"Por favor verificá que tu información cumple con nuestros requerimientos, a "
+"continuación."
 
 #: candidates/templates/candidates/person-edit.html:51
 #: candidates/templates/candidates/person-view.html:99
@@ -1521,7 +1682,9 @@ msgstr "Demografía:"
 msgid ""
 "<strong>You forgot to reference a source!</strong> Can you show us "
 "<em>where</em> you got this information?"
-msgstr "<strong>¡Te olvidaste de citar una fuente!</strong>¿Nos podés contar <em>dónde</em> obtuviste esta información?"
+msgstr ""
+"<strong>¡Te olvidaste de citar una fuente!</strong>¿Nos podés contar "
+"<em>dónde</em> obtuviste esta información?"
 
 #: candidates/templates/candidates/person-edit.html:211
 msgid "What’s your <strong>source of information</strong> for this change?"
@@ -1536,7 +1699,9 @@ msgstr "¡Gracias por tu colaboración!"
 msgid ""
 "Please make sure you read our <a href=\"%(url)s\">guidance on sourcing "
 "fields</a>."
-msgstr "Por favor asegurate de leer nuestra <a href=\"%(url)s\">guía de investigación</a>."
+msgstr ""
+"Por favor asegurate de leer nuestra <a href=\"%(url)s\">guía de "
+"investigación</a>."
 
 #: candidates/templates/candidates/person-edit.html:234
 msgid "Trying to upload a photo?"
@@ -1547,7 +1712,8 @@ msgstr "¿Inentás subir una foto?"
 msgid ""
 "There’s a separate page for <a href=\"%(url)s\">uploading a photo of "
 "%(name)s</a>."
-msgstr "Hay una página especial para <a href=\"%(url)s\">subir fotos de %(name)s</a>."
+msgstr ""
+"Hay una página especial para <a href=\"%(url)s\">subir fotos de %(name)s</a>."
 
 #: candidates/templates/candidates/person-edit.html:244
 msgid "Is this a duplicate person?"
@@ -1653,9 +1819,11 @@ msgstr "%(name)s no fué elegido"
 #: candidates/templates/candidates/person-view.html:93
 #, python-format
 msgid ""
-"We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by"
-" adding one</a>!"
-msgstr "No tenemos la dirección de email de %(name)s, ¡<a href=\"%(url)s\">Ayudanos agregándola</a>!"
+"We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by "
+"adding one</a>!"
+msgstr ""
+"No tenemos la dirección de email de %(name)s, ¡<a href=\"%(url)s\">Ayudanos "
+"agregándola</a>!"
 
 #: candidates/templates/candidates/person-view.html:102
 msgid "Name"
@@ -1741,7 +1909,8 @@ msgstr "Nuestra base de datos la construye gente como vos."
 #: candidates/templates/candidates/person-view.html:196
 msgid ""
 "Please do add extra details about this candidate – it only takes a moment."
-msgstr "Por favor agregá detalles extra de este candidato - sólo toma un momento."
+msgstr ""
+"Por favor agregá detalles extra de este candidato - sólo toma un momento."
 
 #: candidates/templates/candidates/person-view.html:199
 msgid "Edit candidate"
@@ -1762,16 +1931,21 @@ msgstr "API abierta en JSON:"
 #: candidates/templates/candidates/person-view.html:219
 #, python-format
 msgid ""
-"More details about getting <a href=\"%(api_url)s\">the data</a> and <a "
-"href=\"%(about_url)s\">its license</a>."
-msgstr "Más detalles sobre obtener <a href=\"%(api_url)s\">los datos</a> y <a href=\"%(about_url)s\">su licencia</a>."
+"More details about getting <a href=\"%(api_url)s\">the data</a> and <a href="
+"\"%(about_url)s\">its license</a>."
+msgstr ""
+"Más detalles sobre obtener <a href=\"%(api_url)s\">los datos</a> y <a href="
+"\"%(about_url)s\">su licencia</a>."
 
 #: candidates/templates/candidates/person-view.html:228
 msgid ""
 "As a staff user, you can invalidate any cached data for this user. This may "
 "<em>occasionally</em> be necessary if the page is showing stale information "
 "for more than 10 seconds."
-msgstr "Como moderador, podés invalidar los datos en cache (actualizar) para este usuario. Esto puede ocasionalmente ser necesario si la página muestra información vieja por más de 10 segundos."
+msgstr ""
+"Como moderador, podés invalidar los datos en cache (actualizar) para este "
+"usuario. Esto puede ocasionalmente ser necesario si la página muestra "
+"información vieja por más de 10 segundos."
 
 #: candidates/templates/candidates/popit_down.html:6
 msgid "YourNextMP is Temporarily Unavailable"
@@ -1783,13 +1957,16 @@ msgstr "Error"
 
 #: candidates/templates/candidates/popit_down.html:16
 msgid "Sorry, YourNextMP is temporarily unavailable"
-msgstr "Perdón, YoQuieroSaber Investigación está temporalmente fuera de servicio."
+msgstr ""
+"Perdón, YoQuieroSaber Investigación está temporalmente fuera de servicio."
 
 #: candidates/templates/candidates/popit_down.html:18
 msgid ""
 "This usually means that we’re having to do some brief maintenance, and the "
 "site will be back soon."
-msgstr "Esto normalmente significa que estamos haciendo algo de mantenimiento, y el sitio va a estar online de nuevo muy pronto."
+msgstr ""
+"Esto normalmente significa que estamos haciendo algo de mantenimiento, y el "
+"sitio va a estar online de nuevo muy pronto."
 
 #: candidates/templates/candidates/posts.html:9
 msgid "All Posts in Current Elections"
@@ -1815,32 +1992,44 @@ msgstr "Versión simplificada"
 msgid ""
 "This site is run by <a href=\"https://democracyclub.org.uk/\">Democracy "
 "Club</a>."
-msgstr "Este sitio es posible gracias a la colaboración de Congreso Interactivo, OpenKnowledge Argentina, Taringa, HacksLabs, We-Me y muchos voluntarios como vos."
+msgstr ""
+"Este sitio es posible gracias a la colaboración de Congreso Interactivo, "
+"OpenKnowledge Argentina, Taringa, HacksLabs, We-Me y muchos voluntarios como "
+"vos."
 
 #: candidates/templates/candidates/privacy.html:22
 msgid ""
 "We make the following promises about your personal information as a user of "
 "the site:"
-msgstr "Hacemos las siguientes promesas sobre tu información personal como usuario de este sitio:"
+msgstr ""
+"Hacemos las siguientes promesas sobre tu información personal como usuario "
+"de este sitio:"
 
 #: candidates/templates/candidates/privacy.html:28
 msgid ""
 "We will not sell or distribute your email address or other personal "
 "information."
-msgstr "No venderemos ni distribuiremos tu dirección de correo electrónico u otra infrmación personal."
+msgstr ""
+"No venderemos ni distribuiremos tu dirección de correo electrónico u otra "
+"infrmación personal."
 
 #: candidates/templates/candidates/privacy.html:32
 msgid ""
-"We will gladly show you the personal data we store about you in order to run"
-" the website."
-msgstr "Te mostraremos sin problemas los datos que guardamos sobre vos para hacer funcionar el sitio."
+"We will gladly show you the personal data we store about you in order to run "
+"the website."
+msgstr ""
+"Te mostraremos sin problemas los datos que guardamos sobre vos para hacer "
+"funcionar el sitio."
 
 #: candidates/templates/candidates/privacy.html:38
 msgid ""
 "We may use your email address to contact you about your use of the site if "
 "it's problematic (or particularly helpful!), or with occasional "
 "announcements about YourNextMP and other Democracy Club projects."
-msgstr "Podemos usar tu dirección de email para contactarte sobre tu uso del sitio, si hay problemas o si nos ayudas mucho, y con anuncios ocasionales acerca de YoQuieroSaber u otros proyectos del mismo grupo."
+msgstr ""
+"Podemos usar tu dirección de email para contactarte sobre tu uso del sitio, "
+"si hay problemas o si nos ayudas mucho, y con anuncios ocasionales acerca de "
+"YoQuieroSaber u otros proyectos del mismo grupo."
 
 #: candidates/templates/candidates/privacy.html:45
 msgid "Details"
@@ -1851,24 +2040,37 @@ msgid ""
 "As well as your login details, we store your IP address along with any "
 "changes you make to the data on the site.  All this information is "
 "accessible to administrators of the site."
-msgstr "Además de tu nombre de usuario, almacenamos tu dirección IP junto con cualquier cambio que hacés a los datos en el sitio. Esta información es accesible a los administradores del sitio."
+msgstr ""
+"Además de tu nombre de usuario, almacenamos tu dirección IP junto con "
+"cualquier cambio que hacés a los datos en el sitio. Esta información es "
+"accesible a los administradores del sitio."
 
 #: candidates/templates/candidates/privacy.html:53
 msgid ""
-"Please note that this policy refers to the personal information arising from"
-" creating a login on the site, not the personal information about candidates"
-" for elections - the reason for the site to exist is to make information "
+"Please note that this policy refers to the personal information arising from "
+"creating a login on the site, not the personal information about candidates "
+"for elections - the reason for the site to exist is to make information "
 "about those candidates available to members of the public and website "
 "developers so that they can find out more about those candidates, their "
 "promises and policy positions."
-msgstr "Por favor notar que estos términos se refieren a información personal que surje de crear una cuenta en este sitio, no la información personal de candidatos a las elecciones - la razón para la que el sitio existe es hacer disponible información sobre los candidatos al público y otros desarrolladores de software para que puedan informarse mejor sobre esos candidatos, sus promesas y sus posiciones políticas."
+msgstr ""
+"Por favor notar que estos términos se refieren a información personal que "
+"surje de crear una cuenta en este sitio, no la información personal de "
+"candidatos a las elecciones - la razón para la que el sitio existe es hacer "
+"disponible información sobre los candidatos al público y otros "
+"desarrolladores de software para que puedan informarse mejor sobre esos "
+"candidatos, sus promesas y sus posiciones políticas."
 
 #: candidates/templates/candidates/privacy.html:63
 msgid ""
 "We also use Google Analytics to aggregate and track data about usage of the "
 "site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a "
 "browser plugin to opt out of having data collected by Google Analytics</a>."
-msgstr "También usamos Google Analytics para recolectar y registrar datos sobre el uso del sitio; podés usar <a href=\"https://tools.google.com/dlpage/gaoptout/\">una extensión de navegador para evitar que Google Analytics te registre</a>."
+msgstr ""
+"También usamos Google Analytics para recolectar y registrar datos sobre el "
+"uso del sitio; podés usar <a href=\"https://tools.google.com/dlpage/gaoptout/"
+"\">una extensión de navegador para evitar que Google Analytics te registre</"
+"a>."
 
 #: candidates/templates/candidates/recent-changes.html:6
 msgid "Recent changes to the candidate database"
@@ -1930,7 +2132,12 @@ msgid ""
 "emailed to the team of YourNextMP volunteers; they will apply the change "
 "after checking it. If you have any questions about this, please email <a "
 "href=\"%(email)s\">%(email)s</a>."
-msgstr "Como una precaución, esta actualización no fué permitida, pero los detalles han sido enviados por email a un miembro del equipo de voluntarios de YoQuieroSaber Investigación, quien aplicará el cambio luego de verificarlo. Si tenés alguna duda por favor envianos un email <a href=\"%(email)s\">%(email)s</a>."
+msgstr ""
+"Como una precaución, esta actualización no fué permitida, pero los detalles "
+"han sido enviados por email a un miembro del equipo de voluntarios de "
+"YoQuieroSaber Investigación, quien aplicará el cambio luego de verificarlo. "
+"Si tenés alguna duda por favor envianos un email <a href=\"%(email)s\">"
+"%(email)s</a>."
 
 #: candidates/templatetags/metadescription.py:22
 #: candidates/templatetags/metadescription.py:27
@@ -1940,23 +2147,29 @@ msgstr ""
 #: candidates/templatetags/metadescription.py:23
 #, python-format
 msgid "%(name)s stood as an independent candidate in %(post)s in %(election)s"
-msgstr "%(name)s se presentó como candidato independiente para %(post)s en %(election)s"
+msgstr ""
+"%(name)s se presentó como candidato independiente para %(post)s en "
+"%(election)s"
 
 #: candidates/templatetags/metadescription.py:25
 #, python-format
 msgid "%(name)s stood for %(party)s in %(post)s in %(election)s"
-msgstr "%(name)s se presentó por el partido %(party)s para %(post)s en %(election)s"
+msgstr ""
+"%(name)s se presentó por el partido %(party)s para %(post)s en %(election)s"
 
 #: candidates/templatetags/metadescription.py:28
 #, python-format
 msgid ""
 "%(name)s is standing as an independent candidate in %(post)s in %(election)s"
-msgstr "%(name)s se presenta como candidato indpendiente para %(post)s en %(election)s"
+msgstr ""
+"%(name)s se presenta como candidato indpendiente para %(post)s en "
+"%(election)s"
 
 #: candidates/templatetags/metadescription.py:30
 #, python-format
 msgid "%(name)s is standing for %(party)s in %(post)s in %(election)s"
-msgstr "%(name)s se presenta por el partido %(party)s para %(post)s en %(election)s"
+msgstr ""
+"%(name)s se presenta por el partido %(party)s para %(post)s en %(election)s"
 
 #: candidates/templatetags/standing.py:17
 msgid "No information yet"
@@ -1971,20 +2184,22 @@ msgstr "No se presentó"
 msgid "Not standing"
 msgstr "No se presenta"
 
-#: candidates/views/areas.py:24
+#: candidates/views/areas.py:24 candidates/views/areas.py:30
 #, python-brace-format
 msgid "Malformed type and area: '{0}'"
 msgstr "Disculpas, ocurrió un error. Malformed type and area {0}"
 
 #: candidates/views/candidacies.py:29
 msgid "Attempt to edit a candidacy in a locked constituency"
-msgstr "Esta actualización no está permitida porque el distrito ya está cerrado."
+msgstr ""
+"Esta actualización no está permitida porque el distrito ya está cerrado."
 
-#: candidates/views/constituencies.py:191
+#: candidates/views/constituencies.py:195
 msgid "Invalid data POSTed to ConstituencyLockView"
-msgstr "Disculpenos, a ocurrido un error. Invalid data POSTed to ConstituencyLockView"
+msgstr ""
+"Disculpenos, a ocurrido un error. Invalid data POSTed to ConstituencyLockView"
 
-#: candidates/views/constituencies.py:333
+#: candidates/views/constituencies.py:338
 msgid "Result recorded in error, retracting"
 msgstr "Este resultado fue ingresado por error, retractándose"
 
@@ -2086,7 +2301,8 @@ msgstr "El popit_person_id debe ser enteramente numérico"
 msgid ""
 "If you checked 'Other' then you must provide a justification for why we can "
 "use it."
-msgstr "Si seleccionaste 'otra' entones debes justificar por qué podemos usarla."
+msgstr ""
+"Si seleccionaste 'otra' entones debes justificar por qué podemos usarla."
 
 #: moderation_queue/models.py:20
 msgid "Approved"
@@ -2112,13 +2328,17 @@ msgstr "Esta foto está libre de cualquier restricción de copyright"
 msgid ""
 "I own copyright of this photo and I assign the copyright to Democracy Club "
 "Limited in return for it being displayed on YourNextMP"
-msgstr "Poseo el copyright de esta foto y se lo asigno a YoQuieroSaber a cambio de que sea mostrado en este sitio"
+msgstr ""
+"Poseo el copyright de esta foto y se lo asigno a YoQuieroSaber a cambio de "
+"que sea mostrado en este sitio"
 
 #: moderation_queue/models.py:39
 msgid ""
 "This is the candidate's public profile photo from social media (e.g. "
 "Twitter, Facebook) or their official campaign page"
-msgstr "Esta es la foto del perfil del candidato en medios sociales (twitter, facbook, etc), o de su sitio oficial de campaña"
+msgstr ""
+"Esta es la foto del perfil del candidato en medios sociales (twitter, "
+"facbook, etc), o de su sitio oficial de campaña"
 
 #: moderation_queue/models.py:43
 msgid "Other"
@@ -2137,8 +2357,12 @@ msgid ""
 msgid_plural ""
 "<strong>Warning:</strong> there are already %(queued_images)s photos of "
 "%(name)s in the queue, waiting to be moderated:"
-msgstr[0] "<strong>Advertencia:</strong> ya hay %(queued_images)s foto de %(name)s esperando ser aprobada:"
-msgstr[1] "<strong>Advertencia:</strong> ya hay %(queued_images)s fotos de %(name)s esperando ser aprobadas:"
+msgstr[0] ""
+"<strong>Advertencia:</strong> ya hay %(queued_images)s foto de %(name)s "
+"esperando ser aprobada:"
+msgstr[1] ""
+"<strong>Advertencia:</strong> ya hay %(queued_images)s fotos de %(name)s "
+"esperando ser aprobadas:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:16
 #, python-format
@@ -2148,9 +2372,11 @@ msgstr "Foto subida por %(name)s a las %(created)s"
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:25
 #, python-format
 msgid ""
-"If you still want to upload another photo of %(name)s, first select an image"
-" from your computer:"
-msgstr "Si aún querés subir otra foto de %(name)s, primero seleccioná una foto de tu computadora:"
+"If you still want to upload another photo of %(name)s, first select an image "
+"from your computer:"
+msgstr ""
+"Si aún querés subir otra foto de %(name)s, primero seleccioná una foto de tu "
+"computadora:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:29
 msgid "First, select an image from your computer:"
@@ -2160,13 +2386,18 @@ msgstr "Primero, elegí una imágen de tu computadora:"
 msgid ""
 "Now let us know about the copyright of this image by selecting one of these "
 "options or explaining why we can use it:"
-msgstr "Ahora, contanos sobe el los derechos de copia (propiedad intelectual, copyright) de esta imágen seleccionando una de estas opciones, o explicando por qué podemos usarla"
+msgstr ""
+"Ahora, contanos sobe el los derechos de copia (propiedad intelectual, "
+"copyright) de esta imágen seleccionando una de estas opciones, o explicando "
+"por qué podemos usarla"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:47
 msgid ""
 "Here is my justification for why this photo may be reasonably used on the "
 "website, including the source URL:"
-msgstr "Esta es mi justificación de por qué esta foto puede ser rasonablemente utilizada en este sitio, incluyendo la dirección web (URL) de la fuente:"
+msgstr ""
+"Esta es mi justificación de por qué esta foto puede ser rasonablemente "
+"utilizada en este sitio, incluyendo la dirección web (URL) de la fuente:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:54
 #: official_documents/templates/official_documents/upload_document_form.html:14
@@ -2196,7 +2427,8 @@ msgstr "Revisar"
 
 #: moderation_queue/templates/moderation_queue/photo-review-list.html:36
 msgid "<strong>Congratulations!</strong> There are no more photos to review."
-msgstr "<strong>¡Felicitaciones!</strong> No hay más fotos que revisar por ahora."
+msgstr ""
+"<strong>¡Felicitaciones!</strong> No hay más fotos que revisar por ahora."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:17
 #: moderation_queue/templates/moderation_queue/photo-review.html:20
@@ -2207,10 +2439,13 @@ msgstr "Revisar y recortar la foto"
 #, python-format
 msgid ""
 "Please check that this is really <a href=\"%(url)s\">%(name)s</a> "
-"(%(party)s) before approving the upload. This <a "
-"href=\"%(google_image_search_url)s\">Google Image search for candidate "
-"details</a> may be a good start."
-msgstr "Por favor verificá que este sea realmente <a href=\"%(url)s\">%(name)s</a> (%(party)s) antes de aprobar la subida. Esta búsqueda de <a href=\"%(google_image_search_url)s\">Google Images</a> puede ser un buen comienzo."
+"(%(party)s) before approving the upload. This <a href="
+"\"%(google_image_search_url)s\">Google Image search for candidate details</"
+"a> may be a good start."
+msgstr ""
+"Por favor verificá que este sea realmente <a href=\"%(url)s\">%(name)s</a> "
+"(%(party)s) antes de aprobar la subida. Esta búsqueda de <a href="
+"\"%(google_image_search_url)s\">Google Images</a> puede ser un buen comienzo."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:36
 #, python-format
@@ -2218,7 +2453,10 @@ msgid ""
 "If you're trying to find the likely <em>source</em> of this image, you can "
 "also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image "
 "search</a> on the uploaded image."
-msgstr "Si estás intentando encontrar la posible <em>fuente</em> de esta imágen, podés hacer una <a href=\"%(google_reverse_image_search_url)s\">búsqueda inversa de imágenes</a> con la imágen subida."
+msgstr ""
+"Si estás intentando encontrar la posible <em>fuente</em> de esta imágen, "
+"podés hacer una <a href=\"%(google_reverse_image_search_url)s\">búsqueda "
+"inversa de imágenes</a> con la imágen subida."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:41
 msgid "Click and drag in the image to crop"
@@ -2228,7 +2466,9 @@ msgstr "Cliqueá y arrastrá en la imágen para recortarla"
 msgid ""
 "Please crop to just around the candidate's head, since they're displayed in "
 "thumbnail form on the site."
-msgstr "Por favor recortá sólo la cabeza del candidato, porque se muestran en una imágen pequeña en el sitio."
+msgstr ""
+"Por favor recortá sólo la cabeza del candidato, porque se muestran en una "
+"imágen pequeña en el sitio."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:68
 msgid "Minimum X co-ordinate:"
@@ -2253,17 +2493,20 @@ msgstr "Información enviada por los usuarios"
 #: moderation_queue/templates/moderation_queue/photo-review.html:92
 #, python-format
 msgid "Uploaded by user %(username)s with confirmed email <tt>%(email)s</tt>."
-msgstr "Subida por el usuario %(username)s con email confirmado <tt>%(email)s</tt>."
+msgstr ""
+"Subida por el usuario %(username)s con email confirmado <tt>%(email)s</tt>."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:96
 #, python-format
 msgid "(The candidate's unconfirmed email address is <tt>%(email)s</tt>.)"
-msgstr "(La dirección de email sin confirmar del candidato es <tt>%(email)s</tt>.)"
+msgstr ""
+"(La dirección de email sin confirmar del candidato es <tt>%(email)s</tt>.)"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:104
 #, python-format
 msgid "%(username)s asserted that photo is free of copyright restrictions"
-msgstr "%(username)s dijo que esta foto está libre de restricciones de copyright"
+msgstr ""
+"%(username)s dijo que esta foto está libre de restricciones de copyright"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:108
 #, python-format
@@ -2275,14 +2518,18 @@ msgstr "%(username)s asignó el copyright a YoQuieroSaber"
 msgid ""
 "%(username)s said that this is the candidate's public profile photo from "
 "social media or their official campaign page"
-msgstr "%(username)s dijo que esta es la foto del perfil de medios sociales del candidato o de su sitio oficial de campaña"
+msgstr ""
+"%(username)s dijo que esta es la foto del perfil de medios sociales del "
+"candidato o de su sitio oficial de campaña"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:118
 #, python-format
 msgid ""
-"%(username)s's justification for use of this photo was: "
-"&#8220;%(justification)s&#8221;"
-msgstr "%(username)s's dijo que su justificación para usar esta foto es: &#8220;%(justification)s&#8221;"
+"%(username)s's justification for use of this photo was: &#8220;"
+"%(justification)s&#8221;"
+msgstr ""
+"%(username)s's dijo que su justificación para usar esta foto es: &#8220;"
+"%(justification)s&#8221;"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:126
 msgid "Your decision"
@@ -2304,7 +2551,9 @@ msgstr "Porqué <em>vos</em> creés que está permitido:"
 msgid ""
 "Reason for rejection (<strong>Warning:</strong> this will be emailed to the "
 "user):"
-msgstr "Razón para rechazar (<strong>Advertencia:</strong> se enviará por email al usuario):"
+msgstr ""
+"Razón para rechazar (<strong>Advertencia:</strong> se enviará por email al "
+"usuario):"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:156
 msgid "Submit"
@@ -2338,34 +2587,46 @@ msgid ""
 "Thank-you for uploading a photo - you will receive an email when it is "
 "approved to be added to the site, or an explanation for why it cannot be "
 "used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
-msgstr "Gracias por subir una foto - recibirás un email cuando esté aprobada para ser agregada al sitio, o una explicación de porqué no puede ser usada. <a href=\"%(url)s\">Volver a la página de %(name)s.</a>"
+msgstr ""
+"Gracias por subir una foto - recibirás un email cuando esté aprobada para "
+"ser agregada al sitio, o una explicación de porqué no puede ser usada. <a "
+"href=\"%(url)s\">Volver a la página de %(name)s.</a>"
 
 #: moderation_queue/templates/moderation_queue/photo_approved_email.txt:1
 msgid ""
 "Thank-you for submitting a photo to YourNextMP; that's been\n"
 "uploaded now for the candidate page here:"
-msgstr "Gracias por subir una foto a YoQuieroSaber, ha sido subida a la página del candidato, aquí:"
+msgstr ""
+"Gracias por subir una foto a YoQuieroSaber, ha sido subida a la página del "
+"candidato, aquí:"
 
 #: moderation_queue/templates/moderation_queue/photo_approved_email.txt:6
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
 msgid ""
 "Many thanks,\n"
 "The YourNextMP volunteers"
-msgstr "Muchas gracias,\nEl equipo de voluntarios de YoQuieroSaber"
+msgstr ""
+"Muchas gracias,\n"
+"El equipo de voluntarios de YoQuieroSaber"
 
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:1
 #, python-format
 msgid ""
 "Thank-you for uploading a photo of %(candidate_name)s\n"
 "to YourNextMP, but unfortunately we can't use that image because:"
-msgstr "Gracias por subir una foto de  %(candidate_name)s\na YoQuieroSaber, pero desafortunadamente no podemos usarla porque:"
+msgstr ""
+"Gracias por subir una foto de  %(candidate_name)s\n"
+"a YoQuieroSaber, pero desafortunadamente no podemos usarla porque:"
 
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:6
 msgid ""
 "You can just reply to this email if you want to discuss that\n"
 "further, or you can try uploading a photo with a different reason\n"
 "or justification for its use using this link:"
-msgstr "Podés responder a este email si querés seguir conversándolo, o podés intentar subir una foto con una razón o justificación diferente para su uso, en este enlace:"
+msgstr ""
+"Podés responder a este email si querés seguir conversándolo, o podés "
+"intentar subir una foto con una razón o justificación diferente para su uso, "
+"en este enlace:"
 
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:16
 #, python-format
@@ -2381,7 +2642,9 @@ msgstr "Foto aprobada de la cola de moderación"
 msgid ""
 "Approved a photo upload from {uploading_user} who provided the message: "
 "\"{message}\""
-msgstr "Aporobada la foto subida de  {uploading_user} que ingresó el mensaje: \"{message}\""
+msgstr ""
+"Aporobada la foto subida de  {uploading_user} que ingresó el mensaje: "
+"\"{message}\""
 
 #: moderation_queue/views.py:311
 msgid "YourNextMP image upload approved"
@@ -2416,18 +2679,23 @@ msgstr "Dejaste una foto subida por {0} en la cola"
 msgid ""
 "Ignored a photo upload from {uploading_user} (This usually means it was a "
 "duplicate)"
-msgstr "Ignorada una foto subida por {uploading_user} (Esto usualmente significa que era duplicada)"
+msgstr ""
+"Ignorada una foto subida por {uploading_user} (Esto usualmente significa que "
+"era duplicada)"
 
 #: moderation_queue/views.py:383
 #, python-brace-format
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr "Indicaste que una foto subida por {0} debe ser ignorada"
 
-#: mysite/settings.py:347
+#: mysite/settings.py:362
 msgid ""
 "Please don't quote third-party candidate sites —\n"
 "we prefer URLs of news stories or official candidate pages."
-msgstr "Por favor intentá que la fuente de información no sea otro sitio de información sobre candidatos, sino más bien una dirección web (URL) de una noticia o de un sitio oficial del candidato."
+msgstr ""
+"Por favor intentá que la fuente de información no sea otro sitio de "
+"información sobre candidatos, sino más bien una dirección web (URL) de una "
+"noticia o de un sitio oficial del candidato."
 
 #: mysite/templates/account/login.html:7
 #: mysite/templates/account/login.html:10
@@ -2439,9 +2707,14 @@ msgstr "Acceder"
 #, python-format
 msgid ""
 "Please sign in with one\n"
-"of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign up</a>\n"
+"of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign "
+"up</a>\n"
 "for a %(site_name)s account and sign in below:"
-msgstr "Por favor acceda con una de sus cuentas existentes\nen servicios de terceras partes. O <a href=\"%(signup_url)s\">regístrese</a>\npara una cuenta nueva de %(site_name)s y acceda debajo:"
+msgstr ""
+"Por favor acceda con una de sus cuentas existentes\n"
+"en servicios de terceras partes. O <a href=\"%(signup_url)s\">regístrese</"
+"a>\n"
+"para una cuenta nueva de %(site_name)s y acceda debajo:"
 
 #: mysite/templates/account/login.html:26
 msgid "or"
@@ -2452,7 +2725,9 @@ msgstr "o"
 msgid ""
 "If you have not created an account yet, then please\n"
 "<a href=\"%(signup_url)s\">sign up</a> first."
-msgstr "Si no has creado tu cuenta aún, entonces por favor<a href=\"%(signup_url)s\">registrate</a> primero."
+msgstr ""
+"Si no has creado tu cuenta aún, entonces por favor<a href=\"%(signup_url)s"
+"\">registrate</a> primero."
 
 #: mysite/templates/account/login.html:44
 msgid "Forgot Password?"
@@ -2481,7 +2756,9 @@ msgstr "Registrarse"
 #, python-format
 msgid ""
 "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
-msgstr "¿Ya tenés una cuenta? Entonces por favor  <a href=\"%(login_url)s\">accedé</a>."
+msgstr ""
+"¿Ya tenés una cuenta? Entonces por favor  <a href=\"%(login_url)s\">accedé</"
+"a>."
 
 #: mysite/templates/generic_base.html:32
 msgid "YourNextMP - 2015 UK general election candidates"
@@ -2493,17 +2770,25 @@ msgstr "Reportes de errores"
 
 #: mysite/templates/generic_base.html:110
 msgid ""
-"Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a "
-"href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a "
-"href=\"https://mysociety.org\">mySociety</a>."
-msgstr "Apoyado por Congreso Interactivo, Open Knowledge Argentina, Datos Concepción, We Me, Fundación Directorio Legislativo, HacksLabs, Taringa, y otras organizaciones y muchos voluntarios como vos."
+"Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a href="
+"\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a href="
+"\"https://mysociety.org\">mySociety</a>."
+msgstr ""
+"Apoyado por Congreso Interactivo, Open Knowledge Argentina, Datos "
+"Concepción, We Me, Fundación Directorio Legislativo, HacksLabs, Taringa, y "
+"otras organizaciones y muchos voluntarios como vos."
 
 #: mysite/templates/generic_base.html:116
 #, python-format
 msgid ""
-"Built by <a href=\"https://democracyclub.org.uk/\"> <img "
-"src=\"%(logo_url)s\" %%} alt=\"Democracy Club\" class=\"dc-logo\"></a>"
-msgstr "Este sitio es posible gracias al equipo de voluntarios de <a href=\"https://yoquierosaber.org/\"> <img src=\"%(logo_url)s\" %%} alt=\"YoQuieroSaber\" class=\"dc-logo\"></a>, con la colaboración de Congreso Interactivo, OpenKnowledge Argentina, Taringa, HacksLabs, We-Me y muchos voluntarios como vos."
+"Built by <a href=\"https://democracyclub.org.uk/\"> <img src=\"%(logo_url)s"
+"\" %%} alt=\"Democracy Club\" class=\"dc-logo\"></a>"
+msgstr ""
+"Este sitio es posible gracias al equipo de voluntarios de <a href=\"https://"
+"yoquierosaber.org/\"> <img src=\"%(logo_url)s\" %%} alt=\"YoQuieroSaber\" "
+"class=\"dc-logo\"></a>, con la colaboración de Congreso Interactivo, "
+"OpenKnowledge Argentina, Taringa, HacksLabs, We-Me y muchos voluntarios como "
+"vos."
 
 #: official_documents/models.py:23
 msgid "Nomination paper"
@@ -2534,9 +2819,11 @@ msgstr ""
 #: official_documents/templates/official_documents/_post.html:30
 #, python-format
 msgid ""
-"As you have permission to upload documents, you can <a "
-"href=\"%(url)s\">upload a %(type)s</a>."
-msgstr "Como tenés permiso para subir documentos, podés <a href=\"%(url)s\">subir un %(type)s</a>."
+"As you have permission to upload documents, you can <a href=\"%(url)s"
+"\">upload a %(type)s</a>."
+msgstr ""
+"Como tenés permiso para subir documentos, podés <a href=\"%(url)s\">subir un "
+"%(type)s</a>."
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:16
 #, python-format
@@ -2546,16 +2833,20 @@ msgstr "%(type)s para <a href=\"%(url)s\">%(post_label)s</a>."
 #: official_documents/templates/official_documents/officialdocument_detail.html:19
 #, python-format
 msgid ""
-"The source URL for this document was: <a "
-"href=\"%(source_url)s\">%(source_url)s</a>"
-msgstr "La URL de la fuente para este documento era: <a href=\"%(source_url)s\">%(source_url)s</a>"
+"The source URL for this document was: <a href=\"%(source_url)s\">"
+"%(source_url)s</a>"
+msgstr ""
+"La URL de la fuente para este documento era: <a href=\"%(source_url)s\">"
+"%(source_url)s</a>"
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:32
 #, python-format
 msgid ""
 "You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to "
 "delete it)"
-msgstr "Podés <a href=\"%(url)s\">editar esto en la sección de administración</a> (por ejemplo para borrarlo, etc)"
+msgstr ""
+"Podés <a href=\"%(url)s\">editar esto en la sección de administración</a> "
+"(por ejemplo para borrarlo, etc)"
 
 #: official_documents/templates/official_documents/upload_document_form.html:5
 msgid "Upload document"
@@ -2584,11 +2875,15 @@ msgstr "{name} ({party}) ganó en {cons}"
 msgid ""
 "A YourNextMP volunteer recorded at {datetime} that {name} ({party}) won the "
 "ballot in {cons}, quoting the source '{source}')."
-msgstr "Un voluntario de YoQuierSaber registró a las  {datetime} que {name} ({party}) ganó las elecciones en {cons}, citando la fuente '{source}')."
+msgstr ""
+"Un voluntario de YoQuierSaber registró a las  {datetime} que {name} "
+"({party}) ganó las elecciones en {cons}, citando la fuente '{source}')."
 
 #: results/feeds.py:80
 msgid "Election results from YourNextMP (with extra data)"
-msgstr "Resultados de las elecciones de YoQuieroSaber Investigación (con datos adicionales)"
+msgstr ""
+"Resultados de las elecciones de YoQuieroSaber Investigación (con datos "
+"adicionales)"
 
 #: results/feeds.py:81
 msgid "A feed of results from the UK 2015 General Election (with extra data)"
@@ -2599,22 +2894,29 @@ msgstr "Un suministro de resultados de las PASO 2015 (con datos adicionales)"
 msgid "%(pretty_count)s candidate missing %(field)s field</h2>"
 msgid_plural "%(pretty_count)s candidates missing %(field)s field</h2>"
 msgstr[0] "%(pretty_count)s candidato al que le falta el campo %(field)s</h2>"
-msgstr[1] "%(pretty_count)s candidatos a los que les falta el campo %(field)s</h2>"
+msgstr[1] ""
+"%(pretty_count)s candidatos a los que les falta el campo %(field)s</h2>"
 
 #: tasks/templates/tasks/field.html:14
 #, python-format
 msgid ""
 "Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
-msgstr "De %(num_candidates_2015)s candidatos en total (%(percent_empty)s%% están vacíos)"
+msgstr ""
+"De %(num_candidates_2015)s candidatos en total (%(percent_empty)s%% están "
+"vacíos)"
 
 #: tasks/templates/tasks/field.html:21
 #, python-format
 msgid ""
-"Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make"
-" sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
+"Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make "
+"sure you read our <a href=\"https://docs.google.com/document/"
+"d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
 "fields.</a>"
-msgstr "Por favor <a href=\"%(url)s\">colaborá</a> agregegando información faltante.  Asegurate e leer nuestra <a href=\"https://docs.google.com/document/d/11WsPkULuWzQNvy4anK-OWId819Tb0N-aZ7n7v6qYQr4/edit#\">guía para voluntarios.</a>"
+msgstr ""
+"Por favor <a href=\"%(url)s\">colaborá</a> agregegando información "
+"faltante.  Asegurate e leer nuestra <a href=\"https://docs.google.com/"
+"document/d/11WsPkULuWzQNvy4anK-OWId819Tb0N-aZ7n7v6qYQr4/edit#\">guía para "
+"voluntarios.</a>"
 
 #: tasks/templates/tasks/field.html:35
 msgid "edit"
@@ -2625,7 +2927,9 @@ msgstr "editar"
 msgid ""
 "Hi @%(username)s could you add your %(field)s to your YourNextMP.com page "
 "please? https://yournextmp.com/person/%(id)s/"
-msgstr "Hola @%(username)s podrías agregar tu %(field)s a tu perfil de YoQuieroSaber Investigación? https://investigacion.yoquierosaber.org/person/%(id)s/"
+msgstr ""
+"Hola @%(username)s podrías agregar tu %(field)s a tu perfil de YoQuieroSaber "
+"Investigación? https://investigacion.yoquierosaber.org/person/%(id)s/"
 
 #: tasks/templates/tasks/field.html:41
 msgid "Tweet them"
@@ -2653,15 +2957,20 @@ msgstr "¡Podés ayudarnos a mejorar YoQuieroSaber investigación!"
 
 #: tasks/templates/tasks/tasks_home.html:12
 msgid ""
-"YourNextMP.com is a volunteer-sourced database, and that means we constantly"
-" need help in making it better."
-msgstr "YoQuieroSaber Investigación es una base de datos creada en base a una investigación colectiva, lo que significa que constantemente necesitamos ayuda para mejorarla."
+"YourNextMP.com is a volunteer-sourced database, and that means we constantly "
+"need help in making it better."
+msgstr ""
+"YoQuieroSaber Investigación es una base de datos creada en base a una "
+"investigación colectiva, lo que significa que constantemente necesitamos "
+"ayuda para mejorarla."
 
 #: tasks/templates/tasks/tasks_home.html:17
 msgid ""
-"There is a lot of useful information on candidates out there, so if you find"
-" any please do add it to our site."
-msgstr "Hay mucha información útil sobre los candidatos dando vueltas, así que si encontrás algo, por favor agregalo a nuestro sitio, gracias."
+"There is a lot of useful information on candidates out there, so if you find "
+"any please do add it to our site."
+msgstr ""
+"Hay mucha información útil sobre los candidatos dando vueltas, así que si "
+"encontrás algo, por favor agregalo a nuestro sitio, gracias."
 
 #: tasks/templates/tasks/tasks_home.html:22
 msgid "Emails"
@@ -2671,13 +2980,17 @@ msgstr "Correos electrónicos"
 msgid ""
 "At the moment we're trying to get as many email addresses on candidates as "
 "we can."
-msgstr "En este momento estamos intentando obtener todas las dirección de correo electrónico que podamos de los candidatos."
+msgstr ""
+"En este momento estamos intentando obtener todas las dirección de correo "
+"electrónico que podamos de los candidatos."
 
 #: tasks/templates/tasks/tasks_home.html:29
 msgid ""
 "This will allow us to email them directly to ask them to add their own "
 "details."
-msgstr "Esto nos permitirá escribirles directamente para pedirles que agreguen su información ellos mismos."
+msgstr ""
+"Esto nos permitirá escribirles directamente para pedirles que agreguen su "
+"información ellos mismos."
 
 #: tasks/templates/tasks/tasks_home.html:34
 msgid "How to help"
@@ -2688,7 +3001,9 @@ msgstr "Cómo colaborar"
 msgid ""
 "First off you'll need to <a href=\"%(url)s\">log in</a> in order to start "
 "making edits."
-msgstr "Primero vas a tener que <a href=\"%(url)s\">iniciar sesión</a> para comenzar a hacer ediciones."
+msgstr ""
+"Primero vas a tener que <a href=\"%(url)s\">iniciar sesión</a> para comenzar "
+"a hacer ediciones."
 
 #: tasks/templates/tasks/tasks_home.html:43
 #, python-format
@@ -2697,21 +3012,31 @@ msgid ""
 "indicating where we're missing email addresses, so you can start adding "
 "email addresses by <a href=\"%(url)s\">looking up your constituency on the "
 "home page</a>"
-msgstr "Agregamos destacados en las páginas de los candidatos y los distritos indicando dónde nos faltan direcciones de correo electrónico, así que podés ayudarnos a conseguirlas <a href=\"%(url)s\">buscando tu distrito en la página principal</a>"
+msgstr ""
+"Agregamos destacados en las páginas de los candidatos y los distritos "
+"indicando dónde nos faltan direcciones de correo electrónico, así que podés "
+"ayudarnos a conseguirlas <a href=\"%(url)s\">buscando tu distrito en la "
+"página principal</a>"
 
 #: tasks/templates/tasks/tasks_home.html:50
 msgid ""
-"Once you've found a candidate without an email address, you can go searching"
-" for it!"
-msgstr "Una vez que hayas encontrado un candidato sin dirección de email, podés comenzar a buscarla."
+"Once you've found a candidate without an email address, you can go searching "
+"for it!"
+msgstr ""
+"Una vez que hayas encontrado un candidato sin dirección de email, podés "
+"comenzar a buscarla."
 
 #: tasks/templates/tasks/tasks_home.html:55
 msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing "
+"Please make sure you read our <a href=\"https://docs.google.com/document/"
+"d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing "
 "fields</a>, and specifically the part about what sort of email addresses we "
 "accept."
-msgstr "Por favor asegurate de leer nuestra <a href=\"https://docs.google.com/document/d/11WsPkULuWzQNvy4anK-OWId819Tb0N-aZ7n7v6qYQr4/edit#\">guía de voluntarios</a>, especificamente la parte sobre qué tipo de direcciones de correo aceptamos."
+msgstr ""
+"Por favor asegurate de leer nuestra <a href=\"https://docs.google.com/"
+"document/d/11WsPkULuWzQNvy4anK-OWId819Tb0N-aZ7n7v6qYQr4/edit#\">guía de "
+"voluntarios</a>, especificamente la parte sobre qué tipo de direcciones de "
+"correo aceptamos."
 
 #: tasks/templates/tasks/tasks_home.html:62
 msgid ""
@@ -2719,13 +3044,29 @@ msgid ""
 "related to the candidate's campaign. <code>@parliament.uk</code> email "
 "addresses will stop working once Parliament is disbanded, so try to find a "
 "different email address for them if you can. If not, we can always email "
-"everyone with a <code>@parliament.uk</code> address asking them for a better"
-" one."
-msgstr "Preferimos direcciones de correo que puedan ser consideradas públicas y relacionadas a la campaña del candidato, porque las direcciones de correo de oficinas del estado podrían cambiar luego de las elecciones."
+"everyone with a <code>@parliament.uk</code> address asking them for a better "
+"one."
+msgstr ""
+"Preferimos direcciones de correo que puedan ser consideradas públicas y "
+"relacionadas a la campaña del candidato, porque las direcciones de correo de "
+"oficinas del estado podrían cambiar luego de las elecciones."
 
 #: tasks/templates/tasks/tasks_home.html:72
 #, python-format
 msgid ""
 "Once your constituency has all the email addresses entered, you can look at "
 "our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
-msgstr "Una vez que tu distrito tenga todas las direcciones de correo cargadas, podés mirar nuestra <a href=\"%(url)s\">lista de todos los candidatos sin dirección de email</a>!"
+msgstr ""
+"Una vez que tu distrito tenga todas las direcciones de correo cargadas, "
+"podés mirar nuestra <a href=\"%(url)s\">lista de todos los candidatos sin "
+"dirección de email</a>!"
+
+#~ msgid "Malformed parlparse ID found {0}"
+#~ msgstr "Disculpas, ocurrió un error. Malformed parlparse ID found {0}"
+
+#~ msgid ""
+#~ "your information that %(name)s <strong>isn’t</strong> standing for "
+#~ "election in the 2015 general election in %(constituency)s."
+#~ msgstr ""
+#~ "tu información de que %(name)s <strong>no</strong> se presenta para las "
+#~ "PASO 2015en %(constituency)s."


### PR DESCRIPTION
This seemed to just be a case of adding a second version of the button which would only be displayed if the user isn't allowed to edit (assume not logged in). Could just as easily become an only show button if statement.

Includes updated .po files which I had expected to just add "Sign in to add a new candidate" and yet... Hmmm. Will take that under advisement

Closes #388
Closes #408 