### PR TITLE
Add a page showing the posts with most attention needed

### DIFF
--- a/cached_counts/models.py
+++ b/cached_counts/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 from django.dispatch import receiver
 from django.core.urlresolvers import reverse
@@ -47,6 +48,15 @@ class CachedCount(models.Model):
         }
 
         cls.objects.filter(**filters).update(count=models.F('count') + 1)
+
+    @classmethod
+    def get_attention_needed_queryset(cls):
+        # FIXME: this should probably be a queryset method instead.
+        current_election_slugs = [t[0] for t in settings.ELECTIONS_CURRENT]
+        return cls.objects.filter(
+            count_type='post',
+            election__in=current_election_slugs
+        ).order_by('count', '?')
 
 
 @receiver(person_added, sender=PopItPerson)

--- a/cached_counts/templates/attention_needed.html
+++ b/cached_counts/templates/attention_needed.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+<h2>{% trans 'Posts needing most attention' %}</h2>
+    <table class="counts_table">
+        <thead>
+            <th>{% trans "Post Name" %}</th>
+            <th>{% trans "Number of Candidates" %}</th>
+        </thead>
+        <tbody>
+        {% for object in object_list %}
+            <tr {% if object.count == 0 %}class="no_known"{% endif%}>
+                <td><a href="{% url 'constituency' election=object.election post_id=object.object_id ignored_slug=object.name|slugify %}">{{ object.name}}</a></td>
+                <td>{{ object.count}}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+
+{% endblock content %}

--- a/cached_counts/templates/reports.html
+++ b/cached_counts/templates/reports.html
@@ -9,6 +9,16 @@
 
 {% block content %}
 
+  <h2>{% trans 'Which posts have fewest candidates so far?' %}</h2>
+
+  <p>{% url 'attention_needed' as url %}
+     {% blocktrans %}
+        You can see a list of all the posts in current elections
+        <a href="{{ url }}">ordered starting with those with the fewest
+        candidates</a>.
+     {% endblocktrans %}
+  </p>
+
   {% for era, elections in all_elections.items %}
 
     <div class="statistics-elections {{ era }}">

--- a/cached_counts/urls.py
+++ b/cached_counts/urls.py
@@ -1,9 +1,12 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 
-from .views import PartyCountsView, ConstituencyCountsView, ReportsHomeView
+from .views import (
+    PartyCountsView, ConstituencyCountsView, ReportsHomeView, AttentionNeededView
+)
 
 urlpatterns = patterns('',
     url(r'^$', ReportsHomeView.as_view(), name='reports_home'),
+    url(r'^attention-needed$', AttentionNeededView.as_view(), name='attention_needed'),
     url(r'^election/(?P<election>[-\w]+)/parties$', PartyCountsView.as_view(), name='parties_counts'),
     url(r'^election/(?P<election>[-\w]+)/posts$', ConstituencyCountsView.as_view(), name='posts_counts'),
 )

--- a/cached_counts/views.py
+++ b/cached_counts/views.py
@@ -1,8 +1,7 @@
 import json
 
 from django.conf import settings
-from django.http import HttpResponse, Http404
-from django.utils.translation import ugettext as _
+from django.http import HttpResponse
 
 from django.views.generic import ListView, TemplateView
 

--- a/cached_counts/views.py
+++ b/cached_counts/views.py
@@ -124,3 +124,10 @@ class ConstituencyCountsView(ElectionMixin, ListView):
             election=self.kwargs['election'],
             count_type='post',
         )
+
+
+class AttentionNeededView(ListView):
+    template_name = "attention_needed.html"
+
+    def get_queryset(self):
+        return CachedCount.get_attention_needed_queryset()


### PR DESCRIPTION
These are the posts ordered by the number of candidates, from
lowest to highest; this is a reasonable proxy in many cases for
those that need most attention from contributors.
    
This has been particularly requested for Argentina.

This is part of the work to fix #404 (the other bit is to include the
first few items from this list on the front page).