### PR TITLE
Update API help page to generate a link for each csv file

### DIFF
--- a/candidates/templates/candidates/api.html
+++ b/candidates/templates/candidates/api.html
@@ -23,14 +23,40 @@ out more about PopIt here</a>.)
 
 <h2>{% trans "CSV/Excel Download" %}</h2>
 
+<h3>{% trans "Current elections" %}</h3>
+
 <p>
   <ul>
-    <li><a href="{{ MEDIA_URL }}candidates-all.csv">{% trans "Download of the candidates for all elections" %}</a></li>
-    {% for csv in csv_list %}
+    {% for csv in current_csv_list %}
       {% with slug=csv.slug title=csv.name %}
       <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} candidates {% endblocktrans %}</a></li>
       {% endwith %}
     {% endfor %}
+  </ul>
+</p>
+
+
+{% if historic_csv_list %}
+
+<h3>{% trans "Historic elections" %}</h3>
+
+<p>
+  <ul>
+    {% for csv in historic_csv_list %}
+      {% with slug=csv.slug title=csv.name %}
+      <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} candidates {% endblocktrans %}</a></li>
+      {% endwith %}
+    {% endfor %}
+  </ul>
+</p>
+{% endif %}
+
+
+<h3>{% trans "All elections" %}</h3>
+
+<p>
+  <ul>
+    <li><a href="{{ MEDIA_URL }}candidates-all.csv">{% trans "Download of the candidates for all elections" %}</a></li>
   </ul>
 </p>
 

--- a/candidates/templates/candidates/api.html
+++ b/candidates/templates/candidates/api.html
@@ -14,7 +14,7 @@
 <div class="help-api">
 
 <p>{% blocktrans trimmed %}
-The data that's submitted to this site is available as a CSV/Excel download and 
+The data that's submitted to this site is available as a CSV/Excel download and
 programmatically via a RESTful web service called PopIt, which
 stores information about people and their positions in
 organizations. (You can <a href="http://popit.poplus.org/">find
@@ -23,7 +23,17 @@ out more about PopIt here</a>.)
 
 <h2>{% trans "CSV/Excel Download" %}</h2>
 
-<p><a href="{{ MEDIA_URL }}candidates.csv">{% trans "Download of the 2015 candidates" %}</a></p>
+<p>
+  <ul>
+    <li><a href="{{ MEDIA_URL }}candidates-all.csv">{% trans "Download of the candidates for all elections" %}</a></li>
+    {% for csv in csv_list %}
+      {% with slug=csv.slug title=csv.name %}
+      <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} candidates {% endblocktrans %}</a></li>
+      {% endwith %}
+    {% endfor %}
+  </ul>
+</p>
+
 
 <h2>{% trans "API" %}</h2>
 

--- a/candidates/tests/test_api_help_view.py
+++ b/candidates/tests/test_api_help_view.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from mock import patch
+
+from django_webtest import WebTest
+
+@patch('candidates.popit.PopIt')
+class TestApiHelpView(WebTest):
+      def test_api_help(self, mock_popit):
+          response = self.app.get('/help/api')
+          self.assertEqual(response.status_code, 200)
+
+          # check for the all candidates link
+          self.assertIn(
+              'Download of the candidates for all elections',
+              response)
+
+          # check for the all candidates link
+          self.assertIn(
+              'Download of the 2015 General Election candidates',
+              response)

--- a/candidates/views/help.py
+++ b/candidates/views/help.py
@@ -9,12 +9,20 @@ class HelpApiView(PopItApiMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(HelpApiView, self).get_context_data(**kwargs)
 
-        context['csv_list'] = []
+        context['current_csv_list'] = []
         for election, election_data in settings.ELECTIONS_CURRENT:
-            context['csv_list'].append({'slug': election, 'name': election_data['name']})
+            context['current_csv_list'].append({'slug': election, 'name': election_data['name']})
+
+        context['historic_csv_list'] = []
+        current_slugs = [election['slug'] for election in context['current_csv_list']]
+        for election, election_data in settings.ELECTIONS_BY_DATE:
+            if election not in current_slugs:
+                context['historic_csv_list'].append(
+                    {'slug': election, 'name': election_data['name']})
 
         context['popit_url'] = get_base_url()
         return context
+
 
 class HelpAboutView(TemplateView):
     template_name = 'candidates/about.html'

--- a/candidates/views/help.py
+++ b/candidates/views/help.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.views.generic import TemplateView
 
 from ..popit import PopItApiMixin, get_base_url
@@ -7,6 +8,11 @@ class HelpApiView(PopItApiMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(HelpApiView, self).get_context_data(**kwargs)
+
+        context['csv_list'] = []
+        for election, election_data in settings.ELECTIONS_CURRENT:
+            context['csv_list'].append({'slug': election, 'name': election_data['name']})
+
         context['popit_url'] = get_base_url()
         return context
 


### PR DESCRIPTION
Previously here was only ever a single candidates.csv file. Now that we're supporting having more than one election at a time, that's no longer the case.

Fixes #416 